### PR TITLE
Docker files for TensorFlow Serving

### DIFF
--- a/tensorflow-serving/Dockerfiles/Dockerfile
+++ b/tensorflow-serving/Dockerfiles/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG TF_SERVING_VERSION=latest
+ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel
+
+FROM ${TF_SERVING_BUILD_IMAGE} as build_image
+FROM ubuntu:18.04
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+ARG TF_SERVING_VERSION_GIT_COMMIT=head
+
+LABEL maintainer="wdirons@us.ibm.com"
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TF Serving pkg
+COPY --from=build_image /usr/local/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
+
+# Expose ports
+# gRPC
+EXPOSE 8500
+
+# REST
+EXPOSE 8501
+
+# Set where models should be stored in the container
+ENV MODEL_BASE_PATH=/models
+RUN mkdir -p ${MODEL_BASE_PATH}
+
+# The only required piece is the model name in order to differentiate endpoints
+ENV MODEL_NAME=model
+
+# Create a script that runs the model server so we can use environment variables
+# while also passing in arguments from the docker command line
+RUN echo '#!/bin/bash \n\n\
+tensorflow_model_server --port=8500 --rest_api_port=8501 \
+--model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
+"$@"' > /usr/bin/tf_serving_entrypoint.sh \
+&& chmod +x /usr/bin/tf_serving_entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/tf_serving_entrypoint.sh"]

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel
@@ -1,0 +1,122 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:18.04 as base_build
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+ARG TF_SERVING_VERSION_GIT_COMMIT=head
+ARG TF_WHEEL_FILE=tensorflow-1.12.0-cp27-cp27mu-linux_ppc64le.whl
+ARG TF_WHEEL_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/artifact/tensorflow_pkg
+
+LABEL maintainer=wdirons@us.ibm.com
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        automake \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libcurl3-dev \
+        libfreetype6-dev \
+        libhdf5-dev \
+        libpng-dev \
+        libtool \
+        libzmq3-dev \
+        mlocate \
+        openjdk-8-jdk\
+        openjdk-8-jre-headless \
+        pkg-config \
+        python-dev \
+        software-properties-common \
+        swig \
+        unzip \
+        wget \
+        zip \
+        zlib1g-dev \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py
+
+RUN pip --no-cache-dir install \
+    grpcio \
+    h5py \
+    keras_applications \
+    keras_preprocessing \
+    mock \
+    numpy \
+    requests
+
+RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \
+    pip install ${TF_WHEEL_FILE} && \
+    rm -f ${TF_WHEEL_FILE} 
+
+# Install Bazel from source
+# Need >= 0.15.0 so bazel compiles work with docker bind mounts.
+ENV BAZEL_VERSION 0.15.0
+WORKDIR /
+RUN mkdir /bazel && \
+    cd /bazel && \
+    wget --no-verbose https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip && \
+    unzip bazel-$BAZEL_VERSION-dist.zip && \
+    bash ./compile.sh && \
+    cp output/bazel /usr/local/bin && \
+    cd / && \
+    rm -rf /bazel
+
+# Download TF Serving sources (optionally at specific commit).
+WORKDIR /tensorflow-serving
+RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving . && \
+    git remote add upstream https://github.com/tensorflow/serving.git && \
+    if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
+
+
+FROM base_build as binary_build
+# Build, and install TensorFlow Serving
+ARG TF_SERVING_BUILD_OPTIONS="--copt=-mcpu=power8 --copt=-mtune=power8"
+RUN echo "Building with build options: ${TF_SERVING_BUILD_OPTIONS}"
+ARG TF_SERVING_BAZEL_OPTIONS=""
+RUN echo "Building with Bazel options: ${TF_SERVING_BAZEL_OPTIONS}"
+
+RUN bazel build --color=yes --curses=yes \
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/model_servers:tensorflow_model_server && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server \
+    /usr/local/bin/
+
+# Build and install TensorFlow Serving API
+RUN bazel build --color=yes --curses=yes \
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
+    /tmp/pip && \
+    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving*.whl && \
+    rm -rf /tmp/pip
+
+FROM binary_build as clean_build
+# Clean up Bazel cache when done.
+RUN bazel clean --expunge --color=yes && \
+    rm -rf /root/.cache
+CMD ["/bin/bash"]

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
@@ -1,0 +1,173 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvidia/cuda-ppc64le:10.0-base-ubuntu18.04 as base_build
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+ARG TF_SERVING_VERSION_GIT_COMMIT=head
+
+#CPU whl is used because it is for build time only and the python
+#packages requires tensorflow, not tensorflow_gpu
+ARG TF_WHEEL_FILE=tensorflow-1.12.0-cp27-cp27mu-linux_ppc64le.whl
+ARG TF_WHEEL_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/artifact/tensorflow_pkg
+
+LABEL maintainer=wdirons@us.ibm.com
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+ENV NCCL_VERSION=2.3.7
+ENV CUDNN_VERSION=7.3.1.20
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        automake \
+        build-essential \
+        ca-certificates \
+        cuda-command-line-tools-10-0 \
+        cuda-cublas-dev-10-0 \
+        cuda-cudart-dev-10-0 \
+        cuda-cufft-dev-10-0 \
+        cuda-curand-dev-10-0 \
+        cuda-cusolver-dev-10-0 \
+        cuda-cusparse-dev-10-0 \
+        curl \
+        git \
+        libfreetype6-dev \
+        libhdf5-dev \
+        libpng-dev \
+        libtool \
+        libcudnn7=${CUDNN_VERSION}-1+cuda10.0 \
+        libcudnn7-dev=${CUDNN_VERSION}-1+cuda10.0 \
+        libcurl3-dev \
+        libnccl2=${NCCL_VERSION}-1+cuda10.0 \
+        libnccl-dev=${NCCL_VERSION}-1+cuda10.0 \
+        libzmq3-dev \
+        mlocate \
+        openjdk-8-jdk\
+        openjdk-8-jre-headless \
+        pkg-config \
+        python-dev \
+        software-properties-common \
+        swig \
+        unzip \
+        wget \
+        zip \
+        zlib1g-dev \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py
+
+RUN pip --no-cache-dir install \
+    grpcio \
+    h5py \
+    keras_applications \
+    keras_preprocessing \
+    mock \
+    numpy \
+    requests
+
+RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \
+    pip install ${TF_WHEEL_FILE} && \
+    rm -f ${TF_WHEEL_FILE}
+
+# Install Bazel from source
+# Need >= 0.15.0 so bazel compiles work with docker bind mounts.
+ENV BAZEL_VERSION 0.15.0
+WORKDIR /
+RUN mkdir /bazel && \
+    cd /bazel && \
+    wget --no-verbose https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip && \
+    unzip bazel-$BAZEL_VERSION-dist.zip && \
+    bash ./compile.sh && \
+    cp output/bazel /usr/local/bin && \
+    cd / && \
+    rm -rf /bazel
+
+# Build TensorFlow with the CUDA configuration
+ENV CI_BUILD_PYTHON python
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+ENV TF_NEED_CUDA 1
+ENV TF_NEED_TENSORRT 0
+ENV TF_CUDA_COMPUTE_CAPABILITIES=3.5,3.7,5.2,6.0,7.0
+ENV TF_CUDA_VERSION=10.0
+ENV TF_CUDNN_VERSION=7
+
+# Fix paths so that CUDNN can be found: https://github.com/tensorflow/tensorflow/issues/8264
+WORKDIR /
+RUN mkdir /usr/lib/powerpc64le-linux-gnu/include/ && \
+  ln -s /usr/include/cudnn.h /usr/local/cuda/include/cudnn.h && \
+  ln -s /usr/lib/powerpc64le-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so && \
+  ln -s /usr/lib/powerpc64le-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} /usr/local/cuda/lib64/libcudnn.so.${TF_CUDNN_VERSION}
+
+# NCCL 2.x
+ENV TF_NCCL_VERSION=2
+ENV NCCL_INSTALL_PATH=/usr/lib/nccl/lib
+ENV NCCL_HDR_PATH=/usr/lib/nccl/include
+
+# Fix paths so that NCCL can be found
+WORKDIR /
+RUN mkdir -p ${NCCL_INSTALL_PATH} && \
+  mkdir -p ${NCCL_HDR_PATH} && \
+  ln -s /usr/include/nccl.h ${NCCL_HDR_PATH}/nccl.h && \
+  ln -s /usr/lib/powerpc64le-linux-gnu/libnccl.so ${NCCL_INSTALL_PATH}/libnccl.so && \
+  ln -s /usr/lib/powerpc64le-linux-gnu/libnccl.so.${TF_NCCL_VERSION} ${NCCL_INSTALL_PATH}/libnccl.so.${TF_NCCL_VERSION}
+
+# Set TMP for nvidia build environment
+ENV TMP="/tmp"
+
+# Download TF Serving sources (optionally at specific commit).
+WORKDIR /tensorflow-serving
+RUN git clone --branch=${TF_SERVING_VERSION_GIT_BRANCH} https://github.com/tensorflow/serving . && \
+    git remote add upstream https://github.com/tensorflow/serving.git && \
+    if [ "${TF_SERVING_VERSION_GIT_COMMIT}" != "head" ]; then git checkout ${TF_SERVING_VERSION_GIT_COMMIT} ; fi
+
+FROM base_build as binary_build
+# Build, and install TensorFlow Serving
+ARG TF_SERVING_BUILD_OPTIONS="--copt=-mcpu=power8 --copt=-mtune=power8"
+RUN echo "Building with build options: ${TF_SERVING_BUILD_OPTIONS}"
+ARG TF_SERVING_BAZEL_OPTIONS=""
+RUN echo "Building with Bazel options: ${TF_SERVING_BAZEL_OPTIONS}"
+
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
+    bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC"\
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/model_servers:tensorflow_model_server && \
+    cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server \
+    /usr/local/bin/ && \
+    rm /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+# Build and install TensorFlow Serving API
+RUN bazel build --color=yes --curses=yes \
+    ${TF_SERVING_BAZEL_OPTIONS} \
+    --verbose_failures \
+    --output_filter=DONT_MATCH_ANYTHING \
+    ${TF_SERVING_BUILD_OPTIONS} \
+    tensorflow_serving/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
+    /tmp/pip && \
+    pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving*.whl && \
+    rm -rf /tmp/pip
+
+FROM binary_build as clean_build
+# Clean up Bazel cache when done.
+RUN bazel clean --expunge --color=yes && \
+    rm -rf /root/.cache
+CMD ["/bin/bash"]

--- a/tensorflow-serving/Dockerfiles/Dockerfile.gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.gpu
@@ -1,0 +1,72 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG TF_SERVING_VERSION=latest
+ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
+
+FROM ${TF_SERVING_BUILD_IMAGE} as build_image
+FROM nvidia/cuda-ppc64le:10.0-base-ubuntu18.04
+
+ARG TF_SERVING_VERSION_GIT_BRANCH=master
+ARG TF_SERVING_VERSION_GIT_COMMIT=head
+
+LABEL maintainer="wdirons@us.ibm.com"
+LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
+LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
+
+ENV NCCL_VERSION=2.3.7
+ENV CUDNN_VERSION=7.3.1.20
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        cuda-command-line-tools-10-0 \
+        cuda-cublas-10-0 \
+        cuda-cufft-10-0 \
+        cuda-curand-10-0 \
+        cuda-cusolver-10-0 \
+        cuda-cusparse-10-0 \
+        libcudnn7=${CUDNN_VERSION}-1+cuda10.0 \
+        libnccl2=${NCCL_VERSION}-1+cuda10.0 \
+        libgomp1 \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TF Serving GPU pkg
+COPY --from=build_image /usr/local/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
+
+# Expose ports
+# gRPC
+EXPOSE 8500
+
+# REST
+EXPOSE 8501
+
+# Set where models should be stored in the container
+ENV MODEL_BASE_PATH=/models
+RUN mkdir -p ${MODEL_BASE_PATH}
+
+# The only required piece is the model name in order to differentiate endpoints
+ENV MODEL_NAME=model
+
+# Create a script that runs the model server so we can use environment variables
+# while also passing in arguments from the docker command line
+RUN echo '#!/bin/bash \n\n\
+tensorflow_model_server --port=8500 --rest_api_port=8501 \
+--model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
+"$@"' > /usr/bin/tf_serving_entrypoint.sh \
+&& chmod +x /usr/bin/tf_serving_entrypoint.sh
+
+#ENTRYPOINT ["/usr/bin/tf_serving_entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tf_serving_entrypoint.sh"]

--- a/tensorflow-serving/Dockerfiles/README.md
+++ b/tensorflow-serving/Dockerfiles/README.md
@@ -1,0 +1,55 @@
+Files for using the [Docker](http://www.docker.com) container system.
+Please see [Docker instructions](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/docker.md)
+for more info.
+
+Building a ppc64le container from a Dockerfile:
+
+1.  Clone this repo
+
+    ```shell
+    git clone https://github.com/ppc64le/build-scripts/
+    cd build-scripts
+    ```
+
+2.  Build the development image
+
+    *   For CPU:
+
+        ```shell
+        docker build --pull -t $USER/tensorflow-serving-devel \
+          -f tensorflow-serving/Dockerfiles/Dockerfile.devel .
+        ```
+
+    *   For GPU: `
+
+        ```shell
+        docker build --pull -t $USER/tensorflow-serving-devel-gpu \
+          -f tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu .
+        ```
+
+3.  Build the serving image with the development image as a base
+
+    *   For CPU:
+
+        ```shell
+        docker build -t $USER/tensorflow-serving \
+          --build-arg TF_SERVING_BUILD_IMAGE=$USER/tensorflow-serving-devel \
+          -f tensorflow-serving/Dockerfiles/Dockerfile .
+        ```
+
+        Your new Docker image is now `$USER/tensorflow-serving`, which you can
+        [use](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/docker.md##running-a-serving-image)
+        just as you would the standard `tensorflow/serving:latest` image.
+        `tensorflow/serving:latest` image.
+
+    *   For GPU:
+
+        ```shell
+        docker build -t $USER/tensorflow-serving-gpu \
+          --build-arg TF_SERVING_BUILD_IMAGE=$USER/tensorflow-serving-devel-gpu \
+          -f tensorflow-serving/Dockerfiles/Dockerfile.gpu .
+        ```
+
+        Your new Docker image is now `$USER/tensorflow-serving-gpu`, which you can
+        [use](https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/docker.md##running-a-gpu-serving-image)
+        just as you would the standard `tensorflow/serving:latest-gpu` image.


### PR DESCRIPTION
Based on the docker file from:
https://github.com/tensorflow/serving/tree/master/tensorflow_serving/tools/docker

Built bazel from source instead of installing x86 version
Removed TENSORRT as it is not supported on POWER yet
Updated to CUDA 10 and Ubuntu 18.04
Fixed paths for ppc64le
Installed TensorFlow 1.12.0 from OSU release builds as it
can't be installed from pip

Will submit a PR to tensorflow/serving when they move up to CUDA 10.