### PR TITLE
Fix pyzmq issue

### DIFF
--- a/onnx/setup.sh
+++ b/onnx/setup.sh
@@ -44,7 +44,7 @@ if [ "${PYTHON_VERSION}" = "python3" ]; then
 else
     sudo apt-get install -y \
          python-pip
-    sudo pip install virtualenv
+    sudo -H pip install virtualenv
     virtualenv venv_py2
     . ./venv_py2/bin/activate
 fi

--- a/onnx/test.sh
+++ b/onnx/test.sh
@@ -30,6 +30,7 @@ fi
 export SCRIPT_DIR="${PWD}"
 cd onnx
 
+pip install pyzmq==17.1.2
 pip install -q numpy pytest nbval flake8
 
 # onnx c++ API tests


### PR DESCRIPTION
The latest pyzmq, v18.0.0 released on 2/19/2018, doesn't
build/install properly in python3 on ppc64le. Use a known
version before the latest pyzmq can be installed.