### PR TITLE
Cacheless Docker build performance improvements

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     Pillow \
+    future \
     h5py \
     keras_applications \
     keras_preprocessing \
@@ -98,9 +99,6 @@ RUN mkdir /bazel && \
     rm -rf /bazel && \
     cd -
 
-COPY bashrc /etc/bash.bashrc
-RUN chmod a+rwx /etc/bash.bashrc
-
 RUN ${PIP} install jupyter matplotlib
 
 RUN mkdir -p /tf/tensorflow-tutorials && chmod -R a+rwx /tf/
@@ -114,5 +112,8 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN ${PYTHON} -m ipykernel.kernelspec
+
+COPY bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
 
 CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     Pillow \
+    future \
     h5py \
     keras_applications \
     keras_preprocessing \

--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -40,8 +40,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-COPY bashrc /etc/bash.bashrc
-RUN chmod a+rwx /etc/bash.bashrc
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libfreetype6-dev \
@@ -104,5 +102,8 @@ RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
     ${PIP} install ${PACKAGE}
 
 RUN ${PYTHON} -m ipykernel.kernelspec
+
+COPY bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
 
 CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -99,6 +99,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     Pillow \
+    future \
     h5py \
     keras_applications \
     keras_preprocessing \
@@ -124,9 +125,6 @@ RUN mkdir /bazel && \
     rm -rf /bazel && \
     cd -
 
-COPY bashrc /etc/bash.bashrc
-RUN chmod a+rwx /etc/bash.bashrc
-
 RUN ${PIP} install jupyter matplotlib
 
 RUN mkdir -p /tf/tensorflow-tutorials && chmod -R a+rwx /tf/
@@ -140,5 +138,8 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN ${PYTHON} -m ipykernel.kernelspec
+
+COPY bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
 
 CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -99,6 +99,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     Pillow \
+    future \
     h5py \
     keras_applications \
     keras_preprocessing \

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -65,9 +65,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-COPY bashrc /etc/bash.bashrc
-RUN chmod a+rwx /etc/bash.bashrc
-
 RUN ${PIP} install jupyter matplotlib
 
 RUN mkdir -p /tf/tensorflow-tutorials && chmod -R a+rwx /tf/
@@ -125,5 +122,8 @@ RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
     ${PIP} install ${PACKAGE}
 
 RUN ${PYTHON} -m ipykernel.kernelspec
+
+COPY bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
 
 CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]


### PR DESCRIPTION
To improve performance of docker builds with no local cache, docker pull of the
last pushed image can be used in conjunction with the --cached-from tag in
docker build.

This works until docker build encounters the 'COPY' command in the Dockerfile.
Then it stops using the cache. For this reason we moved the 'COPY' command
in the juypter dockerfiles to the end of the dockerfiles.

Docker pull is only used when the tag is latest. Added the -s option to
skip the pull.

Removed unused 'f:' from getopts and reordered them to match the case statement.

Unrelated:
Added future in the devel images for a recent upstream change.