### PR TITLE
Fix warning when tensorflow is imported

### DIFF
--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -58,10 +58,11 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN ${PIP} install --global-option=build_ext \
+RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
+    ${PIP} install --global-option=build_ext \
             --global-option=-I/usr/include/hdf5/serial/ \
             --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py
+            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \

--- a/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
@@ -40,10 +40,11 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN ${PIP} install --global-option=build_ext \
+RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
+    ${PIP} install --global-option=build_ext \
             --global-option=-I/usr/include/hdf5/serial/ \
             --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py
+            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -78,10 +78,11 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN ${PIP} install --global-option=build_ext \
+RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
+    ${PIP} install --global-option=build_ext \
             --global-option=-I/usr/include/hdf5/serial/ \
             --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py
+            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \

--- a/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
@@ -66,10 +66,11 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN ${PIP} install --global-option=build_ext \
+RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
+    ${PIP} install --global-option=build_ext \
             --global-option=-I/usr/include/hdf5/serial/ \
             --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py
+            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \


### PR DESCRIPTION
When importing tensorflow in a python app, it displays the warning:
h5py is running against HDF5 1.10.0 when it was built against 1.8.4, this may cause problems

This warning is false, because it was built against HDF5 1.10.0,
but setup.py was unable to find libhdf5.so to determine the version
number during the build. For this reason we copy libhdf5.so to
/usr/local/lib before the build and remove it after the build.