### PR TITLE
Use python3 for tensorflow docker containers

### DIFF
--- a/tensorflow/Dockerfiles/publish.sh
+++ b/tensorflow/Dockerfiles/publish.sh
@@ -69,6 +69,7 @@ fi
 
 build_push ()
 {
+    echo "Building Docker file with options: Type=$TYPE, Release=$RELEASE, Python_3=$PYTHON_3, JUPYTER=$JUPYTER_ARG"
     if [ $TYPE = "gpu" ]; then
         ARG_SUFFIX="-gpu"
         FILE_PREFIX="gpu"
@@ -92,7 +93,8 @@ build_push ()
         PYTHON="--build-arg USE_PYTHON_3_NOT_2=True"
         PY3="-py3"
     else
-        PYTHON="--build-arg USE_PYTHON_3_NOT_2="
+        #Switch the default image to also be python3
+        PYTHON="--build-arg USE_PYTHON_3_NOT_2=True"
         PY3=""
     fi
     if $JUPYTER_ARG; then


### PR DESCRIPTION
Simple modification to publish.sh to use python3 for all new docker
containers. Basically "latest" and "latest-py3" will be the same
image with different names.

The alternative was to remove all the python 3 or 2 logic, but that
logic might come in handy in the future if we need to support
another python release.

Added a message on what image we are building to the logs to help
with debug.