### PR TITLE
Fix tensorflow devel containers

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -66,12 +66,16 @@ RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    gfortran \
+    gfortran-5 \
     git \
+    libopenblas-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
+    cython \
     Pillow \
     future \
     h5py \

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    numpy && \
+    ${PIP} --no-cache-dir install \
     Pillow \
     future \
     h5py \
@@ -83,12 +85,9 @@ RUN ${PIP} --no-cache-dir install \
     keras_preprocessing \
     matplotlib \
     mock \
-    numpy \
     scipy \
     sklearn \
-    pandas \
-    && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
-    enum34
+    pandas
 
  # Build and install bazel
 ENV BAZEL_VERSION 0.24.1

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -66,12 +66,16 @@ RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    gfortran \
+    gfortran-5 \
     git \
+    libopenblas-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
+    cython \
     Pillow \
     future \
     h5py \

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    numpy && \
+    ${PIP} --no-cache-dir install \
     Pillow \
     future \
     h5py \
@@ -83,12 +85,9 @@ RUN ${PIP} --no-cache-dir install \
     keras_preprocessing \
     matplotlib \
     mock \
-    numpy \
     scipy \
     sklearn \
-    pandas \
-    && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
-    enum34
+    pandas
 
  # Build and install bazel
 ENV BAZEL_VERSION 0.24.1

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -102,6 +102,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    numpy && \
+    ${PIP} --no-cache-dir install \
     Pillow \
     future \
     h5py \
@@ -109,12 +111,9 @@ RUN ${PIP} --no-cache-dir install \
     keras_preprocessing \
     matplotlib \
     mock \
-    numpy \
     scipy \
     sklearn \
-    pandas \
-    && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
-    enum34
+    pandas
 
  # Build and install bazel
 ENV BAZEL_VERSION 0.24.1

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -92,12 +92,16 @@ RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    gfortran \
+    gfortran-5 \
     git \
+    libopenblas-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
+    cython \
     Pillow \
     future \
     h5py \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -102,6 +102,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    numpy && \
+    ${PIP} --no-cache-dir install \
     Pillow \
     future \
     h5py \
@@ -109,12 +111,9 @@ RUN ${PIP} --no-cache-dir install \
     keras_preprocessing \
     matplotlib \
     mock \
-    numpy \
     scipy \
     sklearn \
-    pandas \
-    && test "${USE_PYTHON_3_NOT_2}" -eq 1 && true || ${PIP} --no-cache-dir install \
-    enum34
+    pandas
 
  # Build and install bazel
 ENV BAZEL_VERSION 0.24.1

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -92,12 +92,16 @@ RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    gfortran \
+    gfortran-5 \
     git \
+    libopenblas-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
+    cython \
     Pillow \
     future \
     h5py \


### PR DESCRIPTION
scipy was failing to install in a docker container
first error was: No lapack/blas resources found
second error was no fortran compiler found
third error was cython was not found

Remove enum34 as we no longer support python 2.7

Install cython and numpy first, before the others so the packages
that require them can find them the first time they attempt to compile.
This should save time plus get rid of false error messages in the logs.
