### PR TITLE
Fixes to Docker container exiting on creation.

### DIFF
--- a/orientdb/Dockerfiles/3.0.15_ubuntu_16.04/Dockerfile
+++ b/orientdb/Dockerfiles/3.0.15_ubuntu_16.04/Dockerfile
@@ -40,3 +40,8 @@ WORKDIR /orientdb
 #OrientDb binary
 EXPOSE 2424
 
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]


### PR DESCRIPTION
The image built had issues in it due to which the docker container exited as soon as it was created.
Investigated and found out that 1.) OrientDb http port was not exposed and 2.) Default command to start the OrientDB server were not executed as a part of the Dockerfile.