### PR TITLE
Update for h5py 2 10 0

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -109,7 +109,12 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
 RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888

--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -58,11 +58,6 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
-    ${PIP} install --global-option=build_ext \
-            --global-option=-I/usr/include/hdf5/serial/ \
-            --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -77,7 +72,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             mock \
             werkzeug \
             markdown \
-            pbr
+            pbr \
+            h5py
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -21,6 +21,8 @@
 
 FROM ubuntu:18.04
 
+RUN apt-get update && apt-get install -y curl
+
 ARG USE_PYTHON_3_NOT_2
 ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}
@@ -52,7 +54,12 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
 RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888

--- a/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
@@ -20,6 +20,8 @@
 # for more information.
 FROM ubuntu:18.04
 
+RUN apt-get update && apt-get install -y curl
+
 ARG USE_PYTHON_3_NOT_2
 ARG _PY_SUFFIX=${USE_PYTHON_3_NOT_2:+3}
 ARG PYTHON=python${_PY_SUFFIX}

--- a/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
@@ -39,12 +39,7 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
-    ${PIP} install --global-option=build_ext \
-            --global-option=-I/usr/include/hdf5/serial/ \
-            --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py && rm -f /usr/local/lib/libhdf5.so
+RUN apt-get update && apt-get install -y wget libhdf5-dev pkg-config
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -59,7 +54,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             mock \
             werkzeug \
             markdown \
-            pbr
+            pbr \
+            h5py
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -135,7 +135,12 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
 RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -72,7 +72,12 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
+RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
 RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -78,11 +78,6 @@ WORKDIR /tf
 EXPOSE 8888
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
-    ${PIP} install --global-option=build_ext \
-            --global-option=-I/usr/include/hdf5/serial/ \
-            --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -97,7 +92,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             mock \
             werkzeug \
             markdown \
-            pbr
+            pbr \
+            h5py
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
@@ -66,11 +66,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
 RUN apt-get update && apt-get install -y wget libhdf5-dev
-RUN cp /usr/lib/powerpc64le-linux-gnu/hdf5/serial/libhdf5.so /usr/local/lib/libhdf5.so && \
-    ${PIP} install --global-option=build_ext \
-            --global-option=-I/usr/include/hdf5/serial/ \
-            --global-option=-L/usr/lib/powerpc64le-linux-gnu/hdf5/serial \
-            h5py && rm -f /usr/local/lib/libhdf5.so
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -85,7 +80,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             mock \
             werkzeug \
             markdown \
-            pbr
+            pbr \
+            h5py
 
 # Options:
 #   tensorflow


### PR DESCRIPTION
Update for h5py version 2.10.0

h5py version 2.10.0 was released on September 6th, and it requires
the command pkg-config in order to build from source. In every
docker container except for cpu-ppc64le.Dockerfile we had already
installed pkg-config.

The nice thing about this new version, it is able to build with
libhdf5-dev installed without any hacks to find libhdf5-dev or the
.h file. So these hacks have been removed.

While making this change I also made changes to integrate with latest upstream changes:
    
TensorFlow added new Jupyter notebooks to their docker images in commit:
https://github.com/tensorflow/tensorflow/commit/2feb645aa0ce259f779687add10f9a0e0afeecce

They also added curl to all docker images in commit:
https://github.com/tensorflow/tensorflow/commit/1689e1fe22bf52140f0500a048a03136a466757e