### PR TITLE
Update libcudnn7 and libnccl2 versions

### DIFF
--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -32,10 +32,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusparse-dev-10-0 \
         curl \
         git \
-        libcudnn7=7.4.2.24-1+cuda10.0 \
-        libcudnn7-dev=7.4.2.24-1+cuda10.0 \
-        libnccl2=2.3.7-1+cuda10.0 \
-        libnccl-dev=2.3.7-1+cuda10.0 \
+        libcudnn7=7.6.4.38-1+cuda10.0 \
+        libcudnn7-dev=7.6.4.38-1+cuda10.0 \
+        libnccl2=2.4.8-1+cuda10.0 \
+        libnccl-dev=2.4.8-1+cuda10.0 \
         libcurl3-dev \
         libfreetype6-dev \
         libhdf5-serial-dev \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -32,10 +32,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusparse-dev-10-0 \
         curl \
         git \
-        libcudnn7=7.4.2.24-1+cuda10.0 \
-        libcudnn7-dev=7.4.2.24-1+cuda10.0 \
-        libnccl2=2.3.7-1+cuda10.0 \
-        libnccl-dev=2.3.7-1+cuda10.0 \
+        libcudnn7=7.6.4.38-1+cuda10.0 \
+        libcudnn7-dev=7.6.4.38-1+cuda10.0 \
+        libnccl2=2.4.8-1+cuda10.0 \
+        libnccl-dev=2.4.8-1+cuda10.0 \
         libcurl3-dev \
         libfreetype6-dev \
         libhdf5-serial-dev \

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusolver-10-0 \
         cuda-cusparse-10-0 \
         curl \
-        libcudnn7=7.4.2.24-1+cuda10.0 \
-        libnccl2=2.3.7-1+cuda10.0 \
+        libcudnn7=7.6.4.38-1+cuda10.0 \
+        libnccl2=2.4.8-1+cuda10.0 \
         libfreetype6-dev \
         libhdf5-serial-dev \
         libzmq3-dev \

--- a/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusolver-10-0 \
         cuda-cusparse-10-0 \
         curl \
-        libcudnn7=7.4.2.24-1+cuda10.0 \
-        libnccl2=2.3.7-1+cuda10.0 \
+        libcudnn7=7.6.4.38-1+cuda10.0 \
+        libnccl2=2.4.8-1+cuda10.0 \
         libfreetype6-dev \
         libhdf5-serial-dev \
         libzmq3-dev \


### PR DESCRIPTION
for TensorFlow Docker containers. When TensorFlow was modified to use
the manylinux 2014 docker image for builds, it was built with cudnn
verison 7.6.3. This causes a runtime error when installed in a container
running 7.4.2. To resolve this error we are updating the latest cudnn
version and updating nccl while we are in the file.