### PR TITLE
fix for test cases related to ciphers

### DIFF
--- a/conscrypt/conscrypt.patch
+++ b/conscrypt/conscrypt.patch
@@ -71,38 +71,83 @@ index c1520ac..3e0564d 100644
      components {
          // Builds exe/ which generates the content of NativeConstants.java
          gen(NativeExecutableSpec) {
-diff --git a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
-index 8d8e2d4..43d1b96 100644
---- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
-+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
-@@ -87,7 +87,7 @@ import org.junit.runners.Suite;
-         KeyFactoryTestDSA.class,
-         KeyFactoryTestEC.class,
-         KeyFactoryTestRSA.class,
--        KeyPairGeneratorTest.class,
-+        //KeyPairGeneratorTest.class,
-         KeyPairGeneratorTestDH.class,
-         KeyPairGeneratorTestDSA.class,
-         KeyPairGeneratorTestRSA.class,
-@@ -105,15 +105,15 @@ import org.junit.runners.Suite;
-         KeyStoreBuilderParametersTest.class,
-         SNIHostNameTest.class,
-         SSLContextTest.class,
--        SSLEngineTest.class,
-+        //SSLEngineTest.class,
-         SSLEngineVersionCompatibilityTest.class,
-         SSLParametersTest.class,
-         SSLServerSocketFactoryTest.class,
--        SSLServerSocketTest.class,
-+        //SSLServerSocketTest.class,
-         SSLSessionContextTest.class,
-         SSLSessionTest.class,
-         SSLSocketFactoryTest.class,
--        SSLSocketTest.class,
-+        //SSLSocketTest.class,
-         SSLSocketVersionCompatibilityTest.class,
-         TrustManagerFactoryTest.class,
-         X509KeyManagerTest.class,
+diff --git a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+index 63fc3f5..ad073f7 100644
+--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
++++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
+ import java.security.cert.CertificateException;
+ import java.security.cert.X509Certificate;
+ import java.util.Arrays;
++import java.util.List;
+ import java.util.HashSet;
+ import javax.crypto.SecretKey;
+ import javax.crypto.spec.SecretKeySpec;
+@@ -582,9 +583,13 @@ public class SSLEngineTest {
+                         assertNotNull(session);
+                         // By the point of the handshake where we're validating certificates,
+                         // the hostname is known and the cipher suite should be agreed
++
+                         assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
+-                        assertEquals(referenceEngine.getEnabledCipherSuites()[0],
+-                            session.getCipherSuite());
++
++			String sessionSuite = session.getCipherSuite();
++                        List<String> enabledSuites =
++                            Arrays.asList(referenceEngine.getEnabledCipherSuites());
++                        assertTrue(enabledSuites.contains(sessionSuite));
+                         wasCalled[0] = true;
+                     } catch (Exception e) {
+                         throw new CertificateException("Something broke", e);
+@@ -646,9 +651,13 @@ public class SSLEngineTest {
+                         // By the point of the handshake where we're validating client certificates,
+                         // the cipher suite should be agreed and the server's own certificates
+                         // should have been delivered
+-                        assertEquals(referenceEngine.getEnabledCipherSuites()[0],
+-                            session.getCipherSuite());
++			
++			String sessionSuite = session.getCipherSuite();
++                        List<String> enabledSuites =
++                            Arrays.asList(referenceEngine.getEnabledCipherSuites());
++                        assertTrue(enabledSuites.contains(sessionSuite));                       
+                         assertNotNull(session.getLocalCertificates());
++
+                         assertEquals("CN=localhost",
+                             ((X509Certificate) session.getLocalCertificates()[0])
+                                 .getSubjectDN().getName());
+diff --git a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+index 72bc79e..630be3e 100644
+--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
++++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+@@ -511,8 +511,11 @@ public class SSLSocketTest {
+                         // By the point of the handshake where we're validating certificates,
+                         // the hostname is known and the cipher suite should be agreed
+                         assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
+-                        assertEquals(referenceClientSocket.getEnabledCipherSuites()[0],
+-                            session.getCipherSuite());
++                        String sessionSuite = session.getCipherSuite();
++                        List<String> enabledSuites =
++                            Arrays.asList(referenceClientSocket.getEnabledCipherSuites());
++                        assertTrue(enabledSuites.contains(sessionSuite));
++
+                         wasCalled[0] = true;
+                     } catch (Exception e) {
+                         throw new CertificateException("Something broke", e);
+@@ -592,8 +595,12 @@ public class SSLSocketTest {
+                         // By the point of the handshake where we're validating client certificates,
+                         // the cipher suite should be agreed and the server's own certificates
+                         // should have been delivered
+-                        assertEquals(referenceClientSocket.getEnabledCipherSuites()[0],
+-                            session.getCipherSuite());
++                        
++                        String sessionSuite = session.getCipherSuite();
++                        List<String> enabledSuites =
++                            Arrays.asList(referenceClientSocket.getEnabledCipherSuites());
++                        assertTrue(enabledSuites.contains(sessionSuite));
++			
+                         assertNotNull(session.getLocalCertificates());
+                         assertEquals("CN=localhost",
+                             ((X509Certificate) session.getLocalCertificates()[0])
 diff --git a/openjdk-uber/build.gradle b/openjdk-uber/build.gradle
 index a9078df..c987d22 100644
 --- a/openjdk-uber/build.gradle


### PR DESCRIPTION
add check to see if currently cipher suite is present in the list of supported cipher suites instead of matching the first one in the list 