### PR TITLE
Update cudnn in tensorflow serving

### DIFF
--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel
@@ -74,7 +74,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install Bazel from source
 # Need >= 0.15.0 so bazel compiles work with docker bind mounts.
-ARG BAZEL_VERSION 0.24.1
+ARG BAZEL_VERSION=0.24.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel
@@ -74,7 +74,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install Bazel from source
 # Need >= 0.15.0 so bazel compiles work with docker bind mounts.
-ENV BAZEL_VERSION 0.24.1
+ARG BAZEL_VERSION 0.24.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
@@ -84,7 +84,7 @@ RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Set up Bazel
-ARG BAZEL_VERSION 0.24.1
+ARG BAZEL_VERSION=0.24.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
@@ -24,7 +24,7 @@ LABEL maintainer=wdirons@us.ibm.com
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
 LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
 
-ENV CUDNN_VERSION=7.4.1.5
+ARG CUDNN_VERSION=7.6.4.38
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         automake \
@@ -84,7 +84,7 @@ RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Set up Bazel
-ENV BAZEL_VERSION 0.24.1
+ARG BAZEL_VERSION 0.24.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.gpu
@@ -25,7 +25,7 @@ LABEL maintainer="wdirons@us.ibm.com"
 LABEL tensorflow_serving_github_branchtag=${TF_SERVING_VERSION_GIT_BRANCH}
 LABEL tensorflow_serving_github_commit=${TF_SERVING_VERSION_GIT_COMMIT}
 
-ENV CUDNN_VERSION=7.4.1.5
+ARG CUDNN_VERSION=7.6.4.38
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
Since TensorFlow is building with CUDNN 7.6.3, need to update
CUDNN in the TensorFlow Serving docker container. Change ENV to ARG
so that in the future the version can be changed during the docker build
using the `--build_arg` command line. Made the same change for Bazel.