### PR TITLE
Upgrade Bazel to version 1.1.0

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -90,7 +90,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 0.24.1
+ENV BAZEL_VERSION 1.1.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -90,7 +90,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 0.24.1
+ENV BAZEL_VERSION 1.1.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -116,7 +116,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 0.24.1
+ENV BAZEL_VERSION 1.1.0 
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -116,7 +116,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 0.24.1
+ENV BAZEL_VERSION 1.1.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \


### PR DESCRIPTION
Upstream TensorFlow is now using Bazel 1.1.0 to build the master
branch.