### PR TITLE
Fix scipy install for TensorFlow Dockerfile

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -70,12 +70,14 @@ RUN apt-get update && apt-get install -y \
     gfortran-5 \
     git \
     libopenblas-dev \
+    liblapack-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    pybind11 \
     numpy && \
     ${PIP} --no-cache-dir install \
     Pillow \

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -70,12 +70,14 @@ RUN apt-get update && apt-get install -y \
     gfortran-5 \
     git \
     libopenblas-dev \
+    liblapack-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    pybind11 \
     numpy && \
     ${PIP} --no-cache-dir install \
     Pillow \

--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888
 
-RUN apt-get update && apt-get install -y wget libhdf5-dev
+RUN apt-get update && apt-get install -y wget libhdf5-dev liblapack-dev gfortran
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -80,7 +80,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             werkzeug \
             markdown \
             pbr \
-            h5py
+            h5py \
+            pybind11
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
@@ -41,7 +41,7 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-RUN apt-get update && apt-get install -y wget libhdf5-dev pkg-config
+RUN apt-get update && apt-get install -y wget libhdf5-dev pkg-config liblapack-dev gfortran
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -57,7 +57,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             werkzeug \
             markdown \
             pbr \
-            h5py
+            h5py \
+            pybind11
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -96,12 +96,14 @@ RUN apt-get update && apt-get install -y \
     gfortran-5 \
     git \
     libopenblas-dev \
+    liblapack-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    pybind11 \
     numpy && \
     ${PIP} --no-cache-dir install \
     Pillow \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -96,12 +96,14 @@ RUN apt-get update && apt-get install -y \
     gfortran-5 \
     git \
     libopenblas-dev \
+    liblapack-dev \
     openjdk-8-jdk \
     ${PYTHON}-dev \
     swig
 
 RUN ${PIP} --no-cache-dir install \
     cython \
+    pybind11 \
     numpy && \
     ${PIP} --no-cache-dir install \
     Pillow \

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get autoremove -y && apt-get remove -y wget
 WORKDIR /tf
 EXPOSE 8888
 
-RUN apt-get update && apt-get install -y wget libhdf5-dev
+RUN apt-get update && apt-get install -y wget libhdf5-dev liblapack-dev gfortran
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -98,7 +98,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             werkzeug \
             markdown \
             pbr \
-            h5py
+            h5py \
+            pybind11
 
 # Options:
 #   tensorflow

--- a/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
@@ -65,7 +65,7 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
 
-RUN apt-get update && apt-get install -y wget libhdf5-dev
+RUN apt-get update && apt-get install -y wget libhdf5-dev liblapack-dev gfortran
 
 # These get installed from the tensorflow .whl, but are installed earlier to cache the installs
 RUN ${PIP} --no-cache-dir install --upgrade \
@@ -81,7 +81,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             werkzeug \
             markdown \
             pbr \
-            h5py
+            h5py \
+            pybind11
 
 # Options:
 #   tensorflow


### PR DESCRIPTION
scipy 1.4.1 requires liblapack-dev and pybind11 in order to compile
from source. TensorFlow master branch now requires scipy 1.4.1