### PR TITLE
Fix scipy for tensorflow serving

### DIFF
--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        gfortran \
         libcurl3-dev \
         libfreetype6-dev \
         libhdf5-dev \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurl3-dev \
         libfreetype6-dev \
         libhdf5-dev \
+        liblapack-dev \
         libpng-dev \
         libtool \
         libzmq3-dev \
@@ -62,6 +63,7 @@ RUN pip --no-cache-dir install \
     keras_preprocessing \
     mock \
     numpy \
+    pybind11 \
     requests
 
 RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         libfreetype6-dev \
         libhdf5-dev \
+        liblapack-dev \
         libpng-dev \
         libtool \
         libcudnn7=${CUDNN_VERSION}-1+cuda10.0 \
@@ -74,6 +75,7 @@ RUN pip --no-cache-dir install \
     keras_preprocessing \
     mock \
     numpy \
+    pybind11 \
     requests
 
 RUN wget --no-verbose ${TF_WHEEL_URL}/${TF_WHEEL_FILE} && \

--- a/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
+++ b/tensorflow-serving/Dockerfiles/Dockerfile.devel-gpu
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-cusparse-dev-10-0 \
         curl \
         git \
+        gfortran \
         libfreetype6-dev \
         libhdf5-dev \
         liblapack-dev \


### PR DESCRIPTION
scipy is installed automatically as part of installing the tensorflow
wheel file. We need to ensure liblapack-dev and pybind11 are installed
prior to that so that it build successfully.