### PR TITLE
fix cython error

### DIFF
--- a/onnx/install.sh
+++ b/onnx/install.sh
@@ -31,7 +31,7 @@ export SCRIPT_DIR="${PWD}"
 cd onnx
 
 pip install wheel
-
+pip install cython
 git submodule update --init --recursive
 
 bash -c 'export CMAKE_ARGS="-DONNX_WERROR=ON"; \

--- a/onnx/setup.sh
+++ b/onnx/setup.sh
@@ -27,14 +27,13 @@ if [ ! -n "$NUMCORES" ]; then
 fi
 echo Using $NUMCORES cores
 
-export DEBIAN_FRONTEND=noninteractive
 
-sudo apt-get update 
+sudo apt-get update
 
 sudo apt-get install -y \
          protobuf-compiler \
          libprotobuf-dev \
-         cmake 
+         cmake
 
 # Use python3 or python2 venv based on env variable PYTHON_VERSION
 if [ "${PYTHON_VERSION}" = "python3" ]; then


### PR DESCRIPTION
Fix errors caused by ModuleNotFoundError: No module named 'Cython' for [Onnx nightly build ](https://powerci.osuosl.org/job/onnx-ppc64le-nightly-build/).
@chinhuang007 