### PR TITLE
Move the base url out of dockerfiles and into the publish script

### DIFF
--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -83,27 +83,13 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             h5py \
             pybind11
 
-# Options:
-#   tensorflow
-#   tensorflow-gpu
-#   tf-nightly
-#   tf-nightly-gpu
-ARG TF_PACKAGE=tensorflow
 # CACHE_STOP is used to rerun future commands, otherwise downloading the .whl will be cached and will not pull the most recent version
 ARG CACHE_STOP=1
-RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_GPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tensorflow ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    fi; \
-    MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
+ARG BASE_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/
+RUN MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
     MINOR=`${PYTHON} -c 'import sys; print(sys.version_info[1])'`; \
-    PACKAGE=$(wget --no-verbose -qO- ${BASE}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
-    wget --no-verbose ${BASE}"artifact/tensorflow_pkg/"${PACKAGE}; \
+    PACKAGE=$(wget --no-verbose -qO- ${BASE_URL}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
+    wget --no-verbose ${BASE_URL}"artifact/tensorflow_pkg/"${PACKAGE}; \
     ${PIP} install ${PACKAGE}
 
 RUN ${PYTHON} -m ipykernel.kernelspec

--- a/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le.Dockerfile
@@ -60,27 +60,13 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             h5py \
             pybind11
 
-# Options:
-#   tensorflow
-#   tensorflow-gpu
-#   tf-nightly
-#   tf-nightly-gpu
-ARG TF_PACKAGE=tensorflow
 # CACHE_STOP is used to rerun future commands, otherwise downloading the .whl will be cached and will not pull the most recent version
 ARG CACHE_STOP=1
-RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_GPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tensorflow ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    fi; \
-    MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
+ARG BASE_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/
+RUN MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
     MINOR=`${PYTHON} -c 'import sys; print(sys.version_info[1])'`; \
-    PACKAGE=$(wget --no-verbose -qO- ${BASE}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
-    wget --no-verbose ${BASE}"artifact/tensorflow_pkg/"${PACKAGE}; \
+    PACKAGE=$(wget --no-verbose -qO- ${BASE_URL}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
+    wget --no-verbose ${BASE_URL}"artifact/tensorflow_pkg/"${PACKAGE}; \
     ${PIP} install ${PACKAGE}
 
 COPY bashrc /etc/bash.bashrc

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -109,27 +109,13 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             h5py \
             pybind11
 
-# Options:
-#   tensorflow
-#   tensorflow-gpu
-#   tf-nightly
-#   tf-nightly-gpu
-ARG TF_PACKAGE=tensorflow
 # CACHE_STOP is used to rerun future commands, otherwise downloading the .whl will be cached and will not pull the most recent version
 ARG CACHE_STOP=1
-RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_GPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tensorflow ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    fi; \
-    MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
+ARG BASE_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/
+RUN MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
     MINOR=`${PYTHON} -c 'import sys; print(sys.version_info[1])'`; \
-    PACKAGE=$(wget --no-verbose -qO- ${BASE}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
-    wget --no-verbose ${BASE}"artifact/tensorflow_pkg/"${PACKAGE}; \
+    PACKAGE=$(wget --no-verbose -qO- ${BASE_URL}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
+    wget --no-verbose ${BASE_URL}"artifact/tensorflow_pkg/"${PACKAGE}; \
     ${PIP} install ${PACKAGE}
 
 RUN ${PYTHON} -m ipykernel.kernelspec

--- a/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le.Dockerfile
@@ -92,27 +92,13 @@ RUN ${PIP} --no-cache-dir install --upgrade \
             h5py \
             pybind11
 
-# Options:
-#   tensorflow
-#   tensorflow-gpu
-#   tf-nightly
-#   tf-nightly-gpu
-ARG TF_PACKAGE=tensorflow
 # CACHE_STOP is used to rerun future commands, otherwise downloading the .whl will be cached and will not pull the most recent version
 ARG CACHE_STOP=1
-RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_GPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly-gpu ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tensorflow ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow2_PPC64LE_CPU_Release_Build/lastSuccessfulBuild/; \
-    elif [ ${TF_PACKAGE} = tf-nightly ]; then \
-        BASE=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_CPU_Nightly_Artifact/lastSuccessfulBuild/; \
-    fi; \
-    MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
+ARG BASE_URL=https://powerci.osuosl.org/job/TensorFlow_PPC64LE_GPU_Nightly_Artifact/lastSuccessfulBuild/
+RUN MAJOR=`${PYTHON} -c 'import sys; print(sys.version_info[0])'`; \
     MINOR=`${PYTHON} -c 'import sys; print(sys.version_info[1])'`; \
-    PACKAGE=$(wget --no-verbose -qO- ${BASE}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
-    wget --no-verbose ${BASE}"artifact/tensorflow_pkg/"${PACKAGE}; \
+    PACKAGE=$(wget --no-verbose -qO- ${BASE_URL}"api/xml?xpath=//fileName&wrapper=artifacts" | grep -o "[^<>]*cp${MAJOR}${MINOR}[^<>]*.whl"); \
+    wget --no-verbose ${BASE_URL}"artifact/tensorflow_pkg/"${PACKAGE}; \
     ${PIP} install ${PACKAGE}
 
 COPY bashrc /etc/bash.bashrc


### PR DESCRIPTION
The dockerfiles all have duplicate code to determine the url from which to pull
the tensorflow wheel from. In general there are 4 places to pull the wheel file
from:
cpu release builds
gpu release builds
cpu nightly builds
gpu nightly builds

This logic works fine, but it is better to have it in publish.sh one time, and
then pass the BASE_URL into the dockerfile so it can download and install the
correct wheel.

Sometimes we want to publish a docker image using a URL that isn't one of the 4
builds above. The tool doesn't currently handle that. This PR adds a -u (for url)
option to publish.sh to pass in a URL from which the dockerfile should pull the
tensorflow wheel file from.

This allows for special case builds like LMS and TensorFlow 1.15.X builds to be
published in docker without having to clone the branch and hack the scripts.