### PR TITLE
Fix for "RStudio docker image: startup.sh error message: -e not found"

### DIFF
--- a/rstudio/Dockerfiles/v1.2.1335/Dockerfile
+++ b/rstudio/Dockerfiles/v1.2.1335/Dockerfile
@@ -32,7 +32,7 @@ RUN     rm -rf /var/lib/apt/lists/ && \
         set -e && useradd -m -d /home/rstudio -G sudo rstudio && \
         echo rstudio:rstudio | chpasswd && \
         rstudio-server online && cd / && \
-        echo -e '#!/bin/bash\ncd /usr/sbin\nrstudio-server start' >> startup.sh && \
+        echo "#!/bin/bash\ncd /usr/sbin\nrstudio-server start" >> startup.sh && \
         chmod +x startup.sh
 
 EXPOSE 8787


### PR DESCRIPTION
Fix for "RStudio docker image: startup.sh error message: -e not found"
Issue Link:- https://github.com/ppc64le/build-scripts/issues/131

[RStudio.txt](https://github.com/ppc64le/build-scripts/files/4218156/RStudio.txt)
![RStudio_1_0](https://user-images.githubusercontent.com/37213716/74718531-6dbe2900-5258-11ea-9f5d-082527cb6868.PNG)
