### PR TITLE
Upgrade bazel to 2.0.0

### DIFF
--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -92,7 +92,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 1.2.1
+ENV BAZEL_VERSION 2.0.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le-jupyter.Dockerfile
@@ -111,7 +111,6 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
-RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb

--- a/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-devel-ppc64le.Dockerfile
@@ -92,7 +92,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 1.2.1
+ENV BAZEL_VERSION 2.0.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/cpu-ppc64le-jupyter.Dockerfile
@@ -54,7 +54,6 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
-RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -118,7 +118,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 1.2.1 
+ENV BAZEL_VERSION 2.0.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le-jupyter.Dockerfile
@@ -137,7 +137,6 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
-RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb

--- a/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-devel-ppc64le.Dockerfile
@@ -118,7 +118,7 @@ RUN ${PIP} --no-cache-dir install \
     pandas
 
  # Build and install bazel
-ENV BAZEL_VERSION 1.2.1
+ENV BAZEL_VERSION 2.0.0
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \

--- a/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/Dockerfiles/gpu-ppc64le-jupyter.Dockerfile
@@ -80,7 +80,6 @@ RUN mkdir /.local && chmod a+rwx /.local
 RUN apt-get update && apt-get install -y --no-install-recommends wget
 WORKDIR /tf/tensorflow-tutorials
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
-RUN wget https://raw.githubusercontent.com/tensorflow/models/master/samples/core/tutorials/keras/basic_text_classification.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb
 RUN wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb


### PR DESCRIPTION
These docker images are still used for TensorFlow unit test

Remove deleted juypter notebook

The samples directory in tensorflow/models was deleted in
https://github.com/tensorflow/models/pull/8234/files

The wget failure is now failing docker publish

This example was not included in the upstream tensorflow dockerfiles

