### PR TITLE
Added Dockerfile and readme for Datadog Agent 7.24.0

### DIFF
--- a/d/datadog-agent/Dockerfiles/Dockerfile
+++ b/d/datadog-agent/Dockerfiles/Dockerfile
@@ -1,0 +1,56 @@
+FROM centos:8
+
+# Install all dependencies
+RUN yum install -y wget git python38 python38-devel openssl openssl-devel make gcc gcc-c++ diffutils
+
+ENV PYTHON_VENV=Datadog_agent_venv
+
+RUN python3 -m venv --system-site-packages $PYTHON_VENV \
+	&& source $PYTHON_VENV/bin/activate
+	
+	
+# Install go
+RUN wget https://dl.google.com/go/go1.13.5.linux-ppc64le.tar.gz \
+	&& tar -C /usr/local -xzf go1.13.5.linux-ppc64le.tar.gz \
+	&& rm -rf go1.13.5.linux-ppc64le.tar.gz 
+
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=/root/go
+	
+RUN go version && python3 -m pip install --upgrade pip 
+	
+# Compile and Install cmake 
+RUN wget http://www.cmake.org/files/v3.16/cmake-3.16.4.tar.gz \
+	&& tar xzf cmake-3.16.4.tar.gz \
+	&& rm -rf  cmake-3.16.4.tar.gz \
+	&& cd cmake-3.16.4 \
+	&& ./bootstrap \
+	&& make \
+	&& make install \
+	&& cmake --version	
+	
+	
+# Clone datadog-agent and build 
+ENV PATH=$PATH:/$GOPATH/bin
+
+RUN git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent \
+	&& cd $GOPATH/src/github.com/DataDog/datadog-agent \ 
+	&& git checkout 7.24.0 \
+        && pip install -r requirements.txt \
+	&& invoke deps \
+	&& invoke agent.build --build-exclude=systemd \
+	&& GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint
+
+ENV PATH=$PATH:$GOPATH/src/github.com/DataDog/datadog-agent/bin/agent
+	
+# NOTE: There are 3 failures in test execution, one failure matches with failures on intel(and passes when ran individually).
+# ("INTEGRATION=1 go test -v ./pkg/trace/test/testsuite") Other two work with increased timeout value.
+# Disabling following test execution 
+# RUN invoke  -e test --build-exclude=systemd --python-runtimes 3 --coverage --race --profile --fail-on-fmt --cpus 3
+
+# Removing cmake 
+RUN cd /cmake-3.16.4 && make uninstall	
+
+# Deactivating python8 virtual environment
+# RUN deactivate
+

--- a/d/datadog-agent/Dockerfiles/README.md
+++ b/d/datadog-agent/Dockerfiles/README.md
@@ -1,0 +1,30 @@
+# Build Datadog Agent 7.24.0 docker image
+
+Please find the instructions to build CentOS 8 based docker image of
+Datadog Agent 7.24.0 below. 
+
+## CentOS 8 container
+
+Build the image by executing the following command:
+
+```
+# docker build -f Dockerfile -t datadog-agent-ppc64le:7.24.0 .
+```
+
+Run the Datadog Agent container by executing the following command:
+
+```
+# docker run -it --name dd-agent datadog-agent-ppc64le:7.24.0 "/bin/bash"
+```
+
+## Activate the Python 3.8 virutal environment inside Datadog Agent container
+```
+# source $PYTHON_VENV/bin/activate
+```
+
+## Check the agent version
+Now you can access the agent by calling `agent` command.
+Check version:
+`# agent version`
+
+


### PR DESCRIPTION
Datadog Agent 7.24.0 Dockerfile with CentOS 8 as base and instructions on building image