### PR TITLE
Building no-oss verrsion

### DIFF
--- a/k/kibana/Dockerfiles/7.9.1_centos_7/Dockerfile
+++ b/k/kibana/Dockerfiles/7.9.1_centos_7/Dockerfile
@@ -30,12 +30,13 @@ RUN yum install -y autoconf automake bzip2 gcc-c++ git gzip libtool make openssl
     git apply register_git_hook.diff && \
     groupadd kibana && useradd kibana -g kibana && chown kibana:kibana -R /root && \
     sed -i 's|await run(Tasks.OptimizeBuild);|//await run(Tasks.OptimizeBuild);|g' src/dev/build/build_distributables.ts && \
-    su kibana -c 'yarn kbn bootstrap --oss' && \
-    su kibana -c 'yarn build --skip-os-packages --oss'
+    sed -i '/Tasks.InstallChromium/d' src/dev/build/build_distributables.ts && \
+    su kibana -c 'yarn kbn bootstrap --no-oss' && \
+    su kibana -c 'yarn build --skip-os-packages --no-oss'
 
 RUN mkdir /usr/share/kibana
 WORKDIR /usr/share/kibana
-RUN tar --strip-components=1 -zxf /root/kibana/target/kibana-oss-7.9.1-SNAPSHOT-linux-ppc64le.tar.gz
+RUN tar --strip-components=1 -zxf /root/kibana/target/kibana-7.9.1-SNAPSHOT-linux-ppc64le.tar.gz
 # Ensure that group permissions are the same as user permissions.
 # This will help when relying on GID-0 to run Kibana, rather than UID-1000.
 # OpenShift does this, for example.


### PR DESCRIPTION
I'm changing the build version to use the basic instead of the OSS since this last one lacks several sections/features. You can refer to [this](https://discuss.elastic.co/t/index-management-tab-is-not-visible-after-updating-to-7-9-1/259418) topic that I opened on Elastic portal for more details. 
Using basic version enables several sections as showed on the following image
![image](https://user-images.githubusercontent.com/11238142/103105932-c4be2880-45f6-11eb-9a21-bbb24a529731.png)
