### PR TITLE
Travis-ci: Added support ppc64le buffer-more-ints

### DIFF
--- a/travis-yml/buffer-more-ints.travis.yml
+++ b/travis-yml/buffer-more-ints.travis.yml
@@ -6,7 +6,7 @@
 # Created travis.yml  : No
 # Maintainer          : Devendranath Thadi <devendranath.thadi3@gmail.com>
 #
-# Script License      : MIT License
+# Script License      : Apache License, Version 2 or later
 #
 # ----------------------------------------------------------------------------
 

--- a/travis-yml/buffer-more-ints.travis.yml
+++ b/travis-yml/buffer-more-ints.travis.yml
@@ -1,0 +1,19 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : buffer-more-ints
+# Source Repo         : https://github.com/dpw/node-buffer-more-ints
+# Travis Job Link     : https://travis-ci.com/github/dthadi3/node-buffer-more-ints/builds/211017296
+# Created travis.yml  : No
+# Maintainer          : Devendranath Thadi <devendranath.thadi3@gmail.com>
+#
+# Script License      : MIT License
+#
+# ----------------------------------------------------------------------------
+
+arch:
+  - amd64
+  - ppc64le
+language: node_js
+node_js:
+  - "8"
+  - "9"


### PR DESCRIPTION
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR