### PR TITLE
Create strimzi-kafka-oauth.travis.yml

### DIFF
--- a/travis-ymls/strimzi-kafka-oauth.travis.yml
+++ b/travis-ymls/strimzi-kafka-oauth.travis.yml
@@ -6,7 +6,7 @@
 # Created travis.yml  : No
 # Maintainer          : Nagesh Tarale <Nagesh.Tarale@ibm.com>
 #
-# Script License      : Apache License 2.0
+# Script License      : Apache 2.0
 #
 # ----------------------------------------------------------------------------
 dist: xenial

--- a/travis-ymls/strimzi-kafka-oauth.travis.yml
+++ b/travis-ymls/strimzi-kafka-oauth.travis.yml
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : strimzi-kafka-oauth
+# Source Repo         : https://github.com/strimzi/strimzi-kafka-oauth
+# Travis Job Link     : https://travis-ci.com/github/nageshlop/strimzi-kafka-oauth/builds/211182479
+# Created travis.yml  : No
+# Maintainer          : Nagesh Tarale <Nagesh.Tarale@ibm.com>
+#
+# Script License      : Apache License 2.0
+#
+# ----------------------------------------------------------------------------
+dist: xenial
+sudo: required
+language: java
+arch:
+  - amd64
+  - ppc64le
+jobs:
+  include:
+  - os: linux
+    arch: s390x
+    jdk: openjdk11
+    addons:
+      apt:
+        packages:
+        - maven
+jdk:
+- openjdk8
+- openjdk11
+cache:
+  directories:
+  - "$HOME/.m2"
+addons:
+  hosts:
+  - kafka
+  - keycloak
+  - hydra
+env:
+  global:
+  - PULL_REQUEST=${TRAVIS_PULL_REQUEST}
+  - TAG=${TRAVIS_TAG:-latest}
+  - BRANCH=${TRAVIS_BRANCH:-master}
+  - secure: ZUtBG8nQ3n7r434wrNnkSSMwpqG8Bdqv/nUubP7RPAtGIS/qyWOtYsNLyAj1jKpS5NR0xuqMBSX6BJd8JbG11gpTYH4Gx4aE+TmnhFm489IgywLeEKrlU+5m26I4kMw/P/JoK1jJ6Juu9TyLMLtzkzJhYK1n/VVS1kq2LRXn81ukJrhbxGIqNvk6ok46s0L8SWwjFVyBPgzxc6kcjOQSn9y/zrKsSZUVi6dW0Q7oGTfIMq6LIIlQWk3LJPMW4g8QH6+67WI4z9Ef8z5lzcJ5ypi0tDO9uCiGAGhh61mDdlMJqJNtVDCZz/ofwBRn0ZhAHaT0vGwf78hH/XIUJEQUVKIBndS0QrrIfazhYIVyBMikZI2fFUzXDOtQ21iIWDkcrJowAsaMJzXIzGrjVSc+4rBbhFJV7zlrT0uIPjuQeY0MbyP87qGn2kocIHKtEQWGaqLgUuJO/T4K9ACQvoa+VhgJpAunZ0EwQzZA/4h3qMMveYdHQaWHlbU4xJyOOyS7nGPF/Nm0ZweG8bYOgHUjqBl7LO+AvxXNKRqlrz2PHtRGHSy/j6PnUDZT1cbOaWd7rggfO1hkw39RGc1Gg1xOji/0Jv1MmOXO2GnmkwzWWTL8tOCXI3Yh+v5pnIZc8H8qU71G3CAuNAKefSVoy8uZ2Stg1KzYxpBb5hB5kuU8cpw=
+  - secure: S+vJ6Tgqm23y5QDrpNrQiEOA90Hea6ny/M4FWnV85o2AR4wF5Y3vUpywYjx5gX7jzlaqdakc06WYJdXP9LV8yn/h1okwFbsc7LrZ+xLJcfzQ17eICgSC0oyPGCF5ASt95JJQ8htLknPXlkLo8MfMnGWIEsFvJEBmAC2jPKc6dwoveKHWThW1Spy3h27rAHDfE9PPvyZXBZXktfEDufsqbNKLAaOWTiUmFgC4jFdkcblqijKUlcGbYhEqaNEtIW5EBGzY4bXEzXj75h1pnnJgQIoXDhw/rC62k93DQOurOi6YWt1QPPbOBPGR8d/ikS6PpVac69jY1uuWCxqeg5cZqPephqflgdWqnOBVUekRLDWlk8jgOBTVnSYBxp3UiGcTDIGeW1P5uhBEhFW1pWWm0EzjP62nuRe7wyLVXltGKvFSrzjy7w6ikSpBYrBCWpx5Cpe9pSlrreQd0smHtLL4yjGh6SU4xoOk9VArZ9Hf2GsN2lifMrqXZVPZAuHEiHTjC+vr8JEmfAQ/ZnzxqjggUZ1DiJPs2LEmc0Fe6tH44YLw7mBBuTJb/TpbLZlmA8aq2YQ8T+9XfqkGshJkG4ZY578g6aN64EwE3JQk4PyfcyqeBJ6WkSRD/SF3E2G9FQtAh8DFq51uxPyu3F88i72WqTGq8BiaSXtvVnzHPWhNci0=
+  - secure: jRSKNwKeuq2wRif3UMcq/3V5qnCBLQB9TwyvFUGAs8eYqE83WnOcNqss2psTlY7JOHJUnNrXUvXLwp4bxlhkLqI7bUtRt96bPlZfCXKPUV95y8QMqahH6mMQARzFGhNjsU11ofYQROYoIg8I/IHMvsbQLTaf00D1d3PKqzRP+U9N/Mg8VlbzX45oSAsx7kC3KtTIVZQ1vwxt2wC9JViyDgJBHakH/tpvAbpkbMROQiIEXPY8G7P+6F1Cz4ipEltwIpZPDcRMb09/gAF1qnWIl1Xc3BLQnE+H/fA7nYF6bKwoMwISM3/DwU7n1ola7GWJ+nbuiisMrT1+gBTeQg0UG0mN8ILIyNlhOb3gd+5FvIyXWrXWN0PEonuTRlcYy3Tz7OiGadjQDuHLqH8uoqnZzSHF4Hii6lndkCK8Vrosi8aj42xcahE5MS+KrI7ji5xF2ILajEBcSHWWV3aIfz4zEzI/g+7FgKpTxViru5zw6Jdp+kijN9cMl6rhIKumfhyRzqf9apSTlVCKlc64FqfW6yCz+oVcBFmyLMT+hAWBGaj6qpFIEDEtx8wSfzhMGJCvsqHxNpM02g6WKI9GVGsp9y85sJ6mu/qkmZgw6bINU/pSp1oHquBmfl5OOkjuqOloOtFQMZUVQYBTSCK87DlYKKmCOtvUxeRMsrlbQLR9g2k= # GPG_PASSPHRASE
+script:
+- "./.travis/build.sh"


### PR DESCRIPTION
Added support for ppc64le for the existing travis.yml file in the repo. The build is successful for ppc64le architecture and one of the language is failing on amd64 which was seen in previous build too. Let me know whether the issue should be raised in community for amd64 build failure?