### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/pyparsing_travis.yml
+++ b/pyparsing_travis.yml
@@ -1,0 +1,61 @@
+# Package             : pyparsing
+# Source Repo         : https://github.com/sreekanth370/pyparsing
+# Travis Job Link     : https://travis-ci.com/github/sreekanth370/pyparsing/builds/211990399
+# Created travis.yml  : No
+# Maintainer          : Sreekanth reddy <bsreekanthapps.com>
+#
+# Script License      : Apache License, Version 2 or later
+#
+# ----------------------------------------------------------------------------
+
+arch:
+  - amd64
+  - ppc64le
+  
+dist: bionic
+
+script:
+  - echo "SAMPLE TRAVIS JOB"
+  language: python
+dist: xenial
+
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
+    - python: pypy3
+      env: TOXENV=pypy3
+      #power jobs
+    - python: 3.5
+      env: TOXENV=py35
+      arch: ppc64le
+    - python: 3.6
+      env: TOXENV=py36
+      arch: ppc64le
+    - python: 3.7
+      env: TOXENV=py37
+      arch: ppc64le
+    - python: 3.8
+      env: TOXENV=py38
+      arch: ppc64le
+    - python: 3.9
+      env: TOXENV=py39
+      arch: ppc64le
+  fast_finish: true
+
+install:
+  - pip install tox codecov
+
+script:
+ - tox
+
+after_success:
+  - codecov


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.