### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/travis-ymls/scss-tokenizer_travis.yml
+++ b/travis-ymls/scss-tokenizer_travis.yml
@@ -1,0 +1,24 @@
+# Package             :  scss-tokenizer
+# Source Repo         :  https://github.com/sasstools/scss-tokenizer.git
+# Travis Job Link     :  https://travis-ci.com/github/sreekanth370/scss-tokenizer/builds/211997264
+# Created travis.yml  :  No
+# Maintainer          :  sreekanth reddy <bsreekanthapps@gmail.com>
+#
+# Script License      : Apache License, Version 2 or later
+#
+# ----------------------------------------------------------------------------
+language: node_js
+branches: [master]
+arch:
+  - amd64
+  - ppc64le
+node_js:
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+script:
+  - npm run build
+  - npm run test


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.