### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/travis-ymls/typedarray-to-buffer-travis.yml
+++ b/travis-ymls/typedarray-to-buffer-travis.yml
@@ -1,0 +1,25 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : typedarray-to-buffer 
+# Source Repo         : https://github.com/feross/typedarray-to-buffer.git
+# Travis Job Link     : https://travis-ci.com/github/sreekanth370/typedarray-to-buffer/builds/212316273
+# Created travis.yml  : No
+# Maintainer          : Sreekanth reddy <bsreekanthapps@gmail.com>
+#
+# Script License      : Apache License, Version 2 or later
+#
+# ----------------------------------------------------------------------------
+language: node_js
+arch:
+  - amd64
+  - ppc64le
+node_js:
+  - lts/*
+addons:
+  sauce_connect: true
+  hosts:
+    - airtap.local
+env:
+  global:
+  - secure: i51rE9rZGHbcZWlL58j3H1qtL23OIV2r0X4TcQKNI3pw2mubdHFJmfPNNO19ItfReu8wwQMxOehKamwaNvqMiKWyHfn/QcThFQysqzgGZ6AgnUbYx9od6XFNDeWd1sVBf7QBAL07y7KWlYGWCwFwWjabSVySzQhEBdisPcskfkI=
+  - secure: BKq6/5z9LK3KDkTjs7BGeBZ1KsWgz+MsAXZ4P64NSeVGFaBdXU45+ww1mwxXFt5l22/mhyOQZfebQl+kGVqRSZ+DEgQeCymkNZ6CD8c6w6cLuOJXiXwuu/cDM2DD0tfGeu2YZC7yEikP7BqEFwH3D324rRzSGLF2RSAAwkOI7bE=


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.