### PR TITLE
Travis-ci: added support for ppc64le httpd_configmap_generator

### DIFF
--- a/travis-ymls/httpd_configmap_generator.travis.yml
+++ b/travis-ymls/httpd_configmap_generator.travis.yml
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : httpd_configmap_generator
+# Source Repo         : https://github.com/ManageIQ/httpd_configmap_generator.git
+# Travis Job Link     : https://travis-ci.com/github/dthadi3/httpd_configmap_generator/builds/211998178
+# Created travis.yml  : No
+# Maintainer          : Devendranath Thadi <devendranath.thadi3@gmail.com>
+#
+# Script License      : Apache 2.0
+#
+# ----------------------------------------------------------------------------
+---
+arch:
+- amd64
+- ppc64le
+language: ruby
+rvm:
+- 2.5.8
+- 2.6.6
+cache: bundler
+after_script: bundle exec codeclimate-test-reporter
+notifications:
+  webhooks:
+    urls:
+    - https://webhooks.gitter.im/e/0357efbc3cba43430d2b
+    on_success: change
+    on_failure: always
+    on_start: never


### PR DESCRIPTION
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR.