### PR TITLE
Travis-ci: added support for ppc64le resteasy-spring-boot

### DIFF
--- a/travis-ymls/resteasy-spring-boot.travis.yml
+++ b/travis-ymls/resteasy-spring-boot.travis.yml
@@ -1,0 +1,34 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : resteasy-spring-boot
+# Source Repo         : https://github.com/resteasy/resteasy-spring-boot.git
+# Travis Job Link     : https://travis-ci.com/github/dthadi3/resteasy-spring-boot/builds/212775926
+# Created travis.yml  : No
+# Maintainer          : Devendranath Thadi <devendranath.thadi3@gmail.com>
+#
+# Script License      : Apache 2.0
+#
+# ----------------------------------------------------------------------------
+arch:
+  - amd64
+  - ppc64le
+
+language: java
+# sudo: required
+
+jdk:
+  - openjdk8
+#  - openjdk9
+#  - openjdk10
+  - openjdk11
+
+install: echo $JAVA_HOME && which javac && mvn -B -fae install
+
+after_success:
+  # Installing Codacy code coverage reporter upload tool
+  # This is a workaround until [this issue here](https://github.com/codacy/codacy-coverage-reporter/issues/49) is not solved.
+  - wget https://github.com/codacy/codacy-coverage-reporter/releases/download/1.0.13/codacy-coverage-reporter-1.0.13-assembly.jar -O ccr.jar
+  # Uploading Cobertura report to Codacy
+  - java -cp ccr.jar com.codacy.CodacyCoverageReporter -l Java -r ./resteasy-spring-boot-starter/target/site/cobertura/coverage.xml --projectToken $CODACY_PROJECT_TOKEN
+  # Deploying SNAPSHOT artifacts to Maven Central
+#  - mvn -B -f ./resteasy-spring-boot-starter/pom.xml -s ./resteasy-spring-boot-starter/settings.xml -DskipTests=true -Dcobertura.skip deploy


### PR DESCRIPTION
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR.