### PR TITLE
Travis-CI: Added support power & updated node_js 12 & 14

### DIFF
--- a/travis-ymls/registry.travis.yml
+++ b/travis-ymls/registry.travis.yml
@@ -1,0 +1,19 @@
+# ----------------------------------------------------------------------------
+#
+# Package             : registry
+# Source Repo         : https://github.com/DamonOehlman/registry.git
+# Travis Job Link     : https://travis-ci.com/github/dthadi3/registry/builds/215179504
+# Created travis.yml  : No
+# Maintainer          : Devendranath Thadi <devendranath.thadi3@gmail.com>
+#
+# Script License      : Apache 2.0
+#
+# ----------------------------------------------------------------------------
+arch:
+  - amd64
+  - ppc64le
+language: node_js
+#update node_js versions 12 & 14
+node_js:
+  - 12
+  - 14


### PR DESCRIPTION
I had added ppc64le(Linux on Power) architecture support & updated node_js 12 & 14 versions on Travis-CI in the PR.