### PR TITLE
Knative upstream components v0.19.x build scripts added

### DIFF
--- a/k/knative/v0.18.x/knative-eventing-contrib-v0.18.8_ubuntu_18.04.sh
+++ b/k/knative/v0.18.x/knative-eventing-contrib-v0.18.8_ubuntu_18.04.sh
@@ -1,0 +1,91 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/eventing-contrib
+# Version         : v0.18.8
+# Source repo     : https://github.com/knative/eventing-contrib.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Running k8s cluster
+# Go version 1.14.4
+# Knative Serving and Eventing must be installed
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+
+
+#Clone Knative eventing-contrib repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.18.8 https://github.com/knative/eventing-contrib.git
+cd eventing-contrib
+
+#To run all unit tests
+go test -v ./...
+
+# Build and Publish our test images to the docker daemon.
+sed -i '35 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-e-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-e-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > eventingtemp.txt
+count=$(cat eventingtemp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat eventingtemp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn eventing-contrib test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < eventingtemp.txt
+
+#To run end to end tests 
+
+go test -v -timeout=20m -tags=e2e -count=1 ./test/e2e --dockerrepo $KO_DOCKER_REPO

--- a/k/knative/v0.19.x/knative-client-v0.19.0_ubuntu_18.04.sh
+++ b/k/knative/v0.19.x/knative-client-v0.19.0_ubuntu_18.04.sh
@@ -1,0 +1,94 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/client
+# Version         : v0.19.0
+# Source repo     : https://github.com/knative/client.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Running k8s cluster
+# Go version 1.14.4
+# Knative Serving and Eventing must be installed
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+#Install knative-client
+#Clone Knative client repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.19.0 https://github.com/knative/client.git
+cd client
+#run the following command
+hack/build.sh
+#This results in `kn` binary in a directory where you executed the command. Please move the binary to a directory included in $PATH. 
+cp ./kn $GOPATH/bin/
+#To run all unit tests
+hack/build.sh -t
+
+# Build and Publish our test images to the docker daemon.
+sed -i '35 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+sed -i '38 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-e-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-e-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > clienttemp.txt
+count=$(cat clienttemp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat clienttemp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn client test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < clienttemp.txt
+
+#To run end to end tests 
+
+test/local-e2e-tests.sh -test.timeout=30m --dockerrepo $KO_DOCKER_REPO --ingressendpoint $host 

--- a/k/knative/v0.19.x/knative-eventing-v0.19.0_ubuntu_18.04.sh
+++ b/k/knative/v0.19.x/knative-eventing-v0.19.0_ubuntu_18.04.sh
@@ -1,0 +1,105 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/eventing
+# Version         : v0.19.0
+# Source repo     : https://github.com/knative/eventing.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Running k8s cluster
+# Go version 1.14.4
+#
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+#Install knative-eventing
+
+#Need to export the environment variable SYSTEM_NAMESPACE
+export SYSTEM_NAMESPACE="knative-eventing"
+#Install CRD's for Knative/eventing
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.19.0/eventing-crds.yaml
+#Install core components of eventing
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.19.0/eventing-core.yaml
+#Install a default Channel (In-Memory)
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.19.0/in-memory-channel.yaml
+#Install a Broker layer
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.19.0/mt-channel-broker.yaml
+#Install the Eventing Sugar Controller for running E2E tests 
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.19.0/eventing-sugar-controller.yaml
+
+
+#Clone Knative eventing repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.19.0 https://github.com/knative/eventing.git
+cd eventing
+
+#To run all unit tests
+go test -v ./...
+
+# Build and Publish our test images to the docker daemon.
+sed -i '35 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-e-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-e-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > eventingtemp.txt
+count=$(cat eventingtemp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat eventingtemp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn eventing test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < eventingtemp.txt
+
+#To run end to end tests 
+
+go test -v -timeout=20m -tags=e2e -count=1 ./test/e2e --dockerrepo $KO_DOCKER_REPO

--- a/k/knative/v0.19.x/knative-net-istio-v0.19.0_ubuntu_18.04.sh
+++ b/k/knative/v0.19.x/knative-net-istio-v0.19.0_ubuntu_18.04.sh
@@ -1,0 +1,94 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/Net-istio
+# Version         : v0.19.0
+# Source repo     : https://github.com/knative-sandbox/net-istio.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Running k8s cluster
+# Go version 1.14.4
+# Kn/Serving components (activator, autoscaler, controller and webhook) must be installed and running.
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+
+#Install the Knative Istio controller
+kubectl apply --filename https://github.com/knative/net-istio/releases/download/v0.19.0/release.yaml
+#Clone Knative net-istio repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.19.0 https://github.com/knative-sandbox/net-istio.git
+cd net-istio
+
+#Install testing resources
+ko apply --platform=linux/ppc64le -f test/config > ./log-build.txt 2>&1
+IMAGE=$(cat ./log-build.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}')
+echo "Image is : $IMAGE"
+docker pull $IMAGE
+docker inspect $IMAGE | grep Arch
+# Build and Publish our test images to the docker daemon.
+sed -i '34 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > temp.txt
+count=$(cat temp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat temp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn net-istio test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < temp.txt
+
+#To run end to end tests 
+go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo $KO_DOCKER_REPO --ingressendpoint "$host"

--- a/k/knative/v0.19.x/knative-net-kourier-v0.19.0_ubuntu_18.04.sh
+++ b/k/knative/v0.19.x/knative-net-kourier-v0.19.0_ubuntu_18.04.sh
@@ -1,0 +1,104 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/Net-kourier
+# Version         : v0.19.0
+# Source repo     : https://github.com/knative-sandbox/net-kourier.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Running k8s cluster
+# Go version 1.14.4
+# Kn/Serving components (activator, autoscaler, controller and webhook) must be installed and running.
+# To be authenticated with Quay registry to pull the image
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+
+#Install net-kourier
+kubectl apply --filename https://github.com/knative/net-kourier/releases/download/v0.19.0/kourier.yaml
+# Apply patch to point container image "kourier-gateway" to quay registry
+kubectl -n kourier-system patch deployment 3scale-kourier-gateway -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name":"kourier-gateway","image":"quay.io/maistra/proxyv2-rhel8:1.1.6-ibm"}]}}}}'
+#To configure Knative Serving to use Kourier as the ingress run the below command
+kubectl patch configmap/config-network \
+  --namespace knative-serving \
+  --type merge \
+  --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+
+#Clone Knative net-kourier repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.19.0 https://github.com/knative-sandbox/net-kourier.git
+cd net-kourier
+
+#Install testing resources
+ko apply --platform=linux/ppc64le -f test/config > ./log-build.txt 2>&1
+IMAGE=$(cat ./log-build.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}')
+echo "Image is : $IMAGE"
+docker pull $IMAGE
+docker inspect $IMAGE | grep Arch
+# Build and Publish our test images to the docker daemon.
+sed -i '36 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > temp.txt
+count=$(cat temp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat temp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn net-kourier test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < temp.txt
+
+#To run end to end tests 
+go test -v -tags=e2e -count=1 ./test/e2e --dockerrepo $KO_DOCKER_REPO --ingressendpoint "$host" --ingressClass=kourier.ingress.networking.knative.dev

--- a/k/knative/v0.19.x/knative-serving-v0.19.0_ubuntu_18.04.sh
+++ b/k/knative/v0.19.x/knative-serving-v0.19.0_ubuntu_18.04.sh
@@ -1,0 +1,111 @@
+# ----------------------------------------------------------------------------
+#
+# Package         : knative/serving
+# Version         : v0.19.0
+# Source repo     : https://github.com/knative/serving.git
+# Tested on       : Ubuntu_18.04
+# Script License  : Apache License, Version 2.0
+# Maintainer      : Vijay Kumar H P <vijaykh1@in.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+# ----------------------------------------------------------------------------
+# Prerequisites:
+#
+# Docker must be installed and running
+# Istio for Knative Serving must be installed and running under istio-system namespace
+# Go version 1.14.4
+#
+# ----------------------------------------------------------------------------
+
+set -e
+
+apt-get install git -y
+
+export GOPATH=${HOME}/go
+export GOROOT=/usr/local/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export GOFLAGS="-mod=vendor"
+export GO111MODULE=auto
+
+#Install go packages
+go get -u github.com/golang/dep/cmd/dep
+#Offical ko repo doesnot support multiplatform build
+#PR: https://github.com/google/ko/pull/38
+#Once PR is merged, we can use "go get -u github.com/google/ko/cmd/ko"
+mkdir -p ${GOPATH}/src/github.com/google && cd $_
+git clone -b multi-platform-wip https://github.com/jonjohnsonjr/ko.git
+cd ko/cmd/ko/
+go install
+
+#Create a local registry to push images to
+docker run -it -d --name registry -p 5000:5000 ppc64le/registry:2
+#Export KO_DOCKER_REPO pointing to your docker registry
+host=$(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+export KO_DOCKER_REPO=$host:5000/knative
+
+#Install knative-serving
+
+#Install CRD's for Knative/Serving
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.19.0/serving-crds.yaml
+#Install core components of Serving
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.19.0/serving-core.yaml
+
+#Check for Istio installation 
+if ! kubectl get crds | grep -q gateways.networking.istio.io; then
+    echo "Istio is not installed, please install it" >&2
+    exit 1
+fi
+
+#Install the Knative Istio controller
+kubectl apply --filename https://github.com/knative/net-istio/releases/download/v0.19.0/release.yaml
+
+#Clone Knative Serving repo
+mkdir -p ${GOPATH}/src/knative.dev && cd $_
+git clone --branch v0.19.0 https://github.com/knative/serving.git
+cd serving
+
+#To run all unit tests
+go test ./...
+
+#Install knative serving testing resources
+ko apply --platform=linux/ppc64le -f test/config > ./log-build.txt 2>&1
+IMAGE=$(cat ./log-build.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}')
+echo "Image is : $IMAGE"
+docker pull $IMAGE
+docker inspect $IMAGE | grep Arch
+# Build and Publish our test images to the docker daemon.
+sed -i '34 s|ko resolve|ko resolve --platform=linux/ppc64le|' ./test/upload-test-images.sh
+./test/upload-test-images.sh > log-test-images.txt 2>&1
+
+# Get the names of test images
+echo ""
+echo "Extracting test image data"
+cat log-test-images.txt | grep "Publishing"  | grep ":latest" | awk '{print $4}' > temp.txt
+count=$(cat temp.txt | wc -l)
+echo "Number of test images built = ${count}"
+cat temp.txt
+
+# Loop to pull all the test images
+while IFS= read -r test_image
+do
+    counter=$((counter+1))
+    echo ""
+    echo "Creating image #${counter} for kn serving test image"
+    echo "Test image is: $test_image"
+    docker pull $test_image
+    docker inspect $test_image | grep Arch
+    sleep 3s
+done < temp.txt
+
+#To run end to end tests 
+
+go test -v -timeout=20m -tags=e2e -count=1 ./test/e2e --dockerrepo $KO_DOCKER_REPO --ingressendpoint "$host"


### PR DESCRIPTION
Created scripts for Install/Test Knative packages (Serving, Eventing, net-istio, net-kourier, event-contrib & client ) for respective version and placed under the directory v0.18.x and v0.19.x .