### PR TITLE
Added castor.travis.yml

### DIFF
--- a/travis-ymls/castor.travis.yml
+++ b/travis-ymls/castor.travis.yml
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Package             : castor
+# Source Repo         : https://github.com/castor-data-binding/castor
+# Travis Job Link     : https://travis-ci.com/github/sanjaymsh/castor/builds/216765641
+# Created travis.yml  : No
+# Maintainer          : Sanjay Mishra <snjkmr32@gmail.com>
+# Script License      : Apache License, Version 2 or later
+# ----------------------------------------------------------------------------
+language: java
+arch:
+  - amd64
+  - ppc64le
+jdk:
+  - openjdk9
+  - openjdk10
+# script: "mvn verify"


### PR DESCRIPTION
Hi,

I have added castor.travis.yml.  I have replaced oraclejdk7 and 8 by openjdk9 & 10 And added arch as amd64 and ppc64le. The travis build log can be tracked here https://travis-ci.com/github/sanjaymsh/castor/builds/216765641 . Please review and merge it.

Regards,
Sanjay