### PR TITLE
Dockerfiles for docker v19.03.13 & docker:dind

### DIFF
--- a/d/docker/Dockerfiles/19.03.13_centos8/Dockerfile
+++ b/d/docker/Dockerfiles/19.03.13_centos8/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:8
 
+#Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
 RUN  yum install -y ca-certificates openssh-clients.ppc64le
 
 ENV DOCKER_VERSION 19.03.13

--- a/d/docker/Dockerfiles/19.03.13_centos8/Dockerfile
+++ b/d/docker/Dockerfiles/19.03.13_centos8/Dockerfile
@@ -1,0 +1,23 @@
+FROM centos:8
+
+RUN  yum install -y ca-certificates openssh-clients.ppc64le
+
+ENV DOCKER_VERSION 19.03.13
+
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/7/ppc64le/Packages/c/containerd-1.2.14-1.el7.ppc64le.rpm
+RUN dnf install -y https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-19.03.13/centos/docker-ce-cli-19.03.13-3.el7.ppc64le.rpm
+RUN dnf install -y https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-19.03.13/centos/docker-ce-19.03.13-3.el7.ppc64le.rpm
+
+COPY modprobe.sh /usr/local/bin/modprobe
+COPY docker-entrypoint.sh /usr/local/bin/
+
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=/certs
+# also, ensure the directory pre-exists and has wide enough permissions for "dockerd-entrypoint.sh" to create subdirectories, even when run in "rootless" mode
+RUN mkdir /certs /certs/client && chmod 1777 /certs /certs/client
+# (doing both /certs and /certs/client so that if Docker does a "copy-up" into a volume defined on /certs/client, it will "do the right thing" by default in a way that still works for rootless users)
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh"]

--- a/d/docker/Dockerfiles/19.03.13_centos8/README.md
+++ b/d/docker/Dockerfiles/19.03.13_centos8/README.md
@@ -1,0 +1,15 @@
+Docker build command:
+docker build -t ppc64le/docker:19.03.13
+
+Docker pull command:
+docker pull ppc64le/docker:19.03.13
+
+Sample Docker run command:
+docker run -it -p some_port:2375 --privileged="true" --name=container_name docker 
+
+Additional Details:
+To start the docker service inside the container:
+$service docker start
+
+To run a sample image inside the container:
+$docker run ppc64le/hello-world

--- a/d/docker/Dockerfiles/19.03.13_centos8/README.md
+++ b/d/docker/Dockerfiles/19.03.13_centos8/README.md
@@ -1,3 +1,5 @@
+Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
+
 Docker build command:
 docker build -t ppc64le/docker:19.03.13
 

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/Dockerfile
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/Dockerfile
@@ -1,0 +1,30 @@
+
+FROM ppc64le/docker:19.03.13
+
+# Build docker:19.03 version from 19.03 folder and use local image to create dind image for v19.03
+
+RUN yum install -y  e2fsprogs iptables openssl xfsprogs shadow-utils e2fsprogs-devel.ppc64le xz pigz wget 
+
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+
+
+RUN set -eux; \
+	groupadd dockremap; \
+	adduser -g dockremap dockremap; \
+	echo 'dockremap:165536:65536' >> /etc/subuid; \
+	echo 'dockremap:165536:65536' >> /etc/subgid
+
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT ed89041433a031cafc0a0f19cfe573c31688d377
+
+RUN set -eux; \
+	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+	chmod +x /usr/local/bin/dind
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]
+CMD []

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/Dockerfile
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/Dockerfile
@@ -1,6 +1,7 @@
 
 FROM ppc64le/docker:19.03.13
 
+#Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
 # Build docker:19.03 version from 19.03 folder and use local image to create dind image for v19.03
 
 RUN yum install -y  e2fsprogs iptables openssl xfsprogs shadow-utils e2fsprogs-devel.ppc64le xz pigz wget 

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
@@ -1,0 +1,10 @@
+Base Image:
+
+We have used ppc64le/docker:19.03.13 as base image and its not published yet , so build ppc64le/docker:19.03.13 using Dockerfile available at https://github.com/ppc64le/build-scripts/tree/master/d/docker/19.03.13_centos8/Dockerfile
+
+Docker build command:
+docker build -t ppc64le/docker:dind-19.03.13
+
+Docker pull command:
+docker pull ppc64le/docker:dind-19.03.13
+

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
@@ -5,7 +5,7 @@ Note - Files have be adapted from community dockerfiles available @ https://gith
 We have used ppc64le/docker:19.03.13 as base image and its not published yet , so build ppc64le/docker:19.03.13 using Dockerfile available at https://github.com/ppc64le/build-scripts/tree/master/d/docker/19.03.13_centos8/Dockerfile
 
 Docker build command:
-docker build -t ppc64le/docker:dind-19.03.13
+docker build -t ppc64le/docker:dind-19.03.13 .
 
 Docker pull command:
 docker pull ppc64le/docker:dind-19.03.13

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/README.md
@@ -1,5 +1,7 @@
 Base Image:
 
+Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
+
 We have used ppc64le/docker:19.03.13 as base image and its not published yet , so build ppc64le/docker:19.03.13 using Dockerfile available at https://github.com/ppc64le/build-scripts/tree/master/d/docker/19.03.13_centos8/Dockerfile
 
 Docker build command:

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/dockerd-entrypoint.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/dockerd-entrypoint.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4096
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+# no arguments passed
+# or first arg is `-f` or `--some-option`
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
+	uid="$(id -u)"
+	if [ "$uid" = '0' ]; then
+		dockerSocket='unix:///var/run/docker.sock'
+	else
+		# if we're not root, we must be trying to run rootless
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
+	fi
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
+
+	# add our default arguments
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2376:2376/tcp"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
+	fi
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	find /run /var/run -iname 'docker*.pid' -delete || :
+
+	uid="$(id -u)"
+	if [ "$uid" != '0' ]; then
+		# if we're not root, we must be trying to run rootless
+		if ! command -v rootlesskit > /dev/null; then
+			echo >&2 "error: attempting to run rootless dockerd but missing 'rootlesskit' (perhaps the 'docker:dind-rootless' image variant is intended?)"
+			exit 1
+		fi
+		user="$(id -un 2>/dev/null || :)"
+		if ! grep -qE "^($uid${user:+|$user}):" /etc/subuid || ! grep -qE "^($uid${user:+|$user}):" /etc/subgid; then
+			echo >&2 "error: attempting to run rootless dockerd but missing necessary entries in /etc/subuid and/or /etc/subgid for $uid"
+			exit 1
+		fi
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		export XDG_RUNTIME_DIR
+		if ! mkdir -p "$XDG_RUNTIME_DIR" || [ ! -w "$XDG_RUNTIME_DIR" ] || ! mkdir -p "$HOME/.local/share/docker" || [ ! -w "$HOME/.local/share/docker" ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need writable HOME ($HOME) and XDG_RUNTIME_DIR ($XDG_RUNTIME_DIR) for user $uid"
+			exit 1
+		fi
+		if [ -f /proc/sys/kernel/unprivileged_userns_clone ] && unprivClone="$(cat /proc/sys/kernel/unprivileged_userns_clone)" && [ "$unprivClone" != '1' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'kernel.unprivileged_userns_clone' (/proc/sys/kernel/unprivileged_userns_clone) set to 1"
+			exit 1
+		fi
+		if [ -f /proc/sys/user/max_user_namespaces ] && maxUserns="$(cat /proc/sys/user/max_user_namespaces)" && [ "$maxUserns" = '0' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'user.max_user_namespaces' (/proc/sys/user/max_user_namespaces) set to a sufficiently large value"
+			exit 1
+		fi
+		# TODO overlay support detection?
+		exec rootlesskit \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--disable-host-loopback \
+			--port-driver=builtin \
+			--copy-up=/etc \
+			--copy-up=/run \
+			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+			"$@"
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
+	fi
+else
+	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too
+	set -- docker-entrypoint.sh "$@"
+fi
+
+exec "$@"

--- a/d/docker/Dockerfiles/19.03.13_centos8/dind/dockerd-entrypoint.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/dind/dockerd-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-
+#Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
 _tls_ensure_private() {
 	local f="$1"; shift
 	[ -s "$f" ] || openssl genrsa -out "$f" 4096

--- a/d/docker/Dockerfiles/19.03.13_centos8/docker-entrypoint.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/docker-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker help "$1" > /dev/null 2>&1; then
+	set -- docker "$@"
+fi
+
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if we have no DOCKER_HOST but we do have the default Unix socket (standard or rootless), use it explicitly
+if [ -z "${DOCKER_HOST:-}" ] && [ -S /var/run/docker.sock ]; then
+	export DOCKER_HOST=unix:///var/run/docker.sock
+elif [ -z "${DOCKER_HOST:-}" ] && XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" && [ -S "$XDG_RUNTIME_DIR/docker.sock" ]; then
+	export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/docker.sock"
+fi
+
+# if DOCKER_HOST isn't set (no custom setting, no default socket), let's set it to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ "${DOCKER_HOST#tcp:}" != "$DOCKER_HOST" ] \
+	&& [ -z "${DOCKER_TLS_VERIFY:-}" ] \
+	&& [ -z "${DOCKER_CERT_PATH:-}" ] \
+	&& _should_tls \
+; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-docker ... docker:dind ...
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
+exec "$@"

--- a/d/docker/Dockerfiles/19.03.13_centos8/docker-entrypoint.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-
+#Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
 	set -- docker "$@"

--- a/d/docker/Dockerfiles/19.03.13_centos8/modprobe.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/modprobe.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# "modprobe" without modprobe
+# https://twitter.com/lucabruno/status/902934379835662336
+
+# this isn't 100% fool-proof, but it'll have a much higher success rate than simply using the "real" modprobe
+
+# Docker often uses "modprobe -va foo bar baz"
+# so we ignore modules that start with "-"
+for module; do
+	if [ "${module#-}" = "$module" ]; then
+		ip link show "$module" || true
+		lsmod | grep "$module" || true
+	fi
+done
+
+# remove /usr/local/... from PATH so we can exec the real modprobe as a last resort
+export PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+exec modprobe "$@"

--- a/d/docker/Dockerfiles/19.03.13_centos8/modprobe.sh
+++ b/d/docker/Dockerfiles/19.03.13_centos8/modprobe.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 
+#Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
 # "modprobe" without modprobe
 # https://twitter.com/lucabruno/status/902934379835662336
 

--- a/d/docker/Dockerfiles/20.10_alpine/Dockerfile
+++ b/d/docker/Dockerfiles/20.10_alpine/Dockerfile
@@ -1,0 +1,45 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM ppc64le/alpine:3.13
+
+RUN set -eux; \
+        apkArch="$(apk --print-arch)"; \
+        apk add docker; \
+        dockerd --version; \
+        docker --version
+
+RUN apk add --no-cache \
+		ca-certificates \
+# DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
+		openssh-client
+
+# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV DOCKER_VERSION 20.10.3
+# TODO ENV DOCKER_SHA256
+# https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
+# (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
+
+
+COPY modprobe.sh /usr/local/bin/modprobe
+COPY docker-entrypoint.sh /usr/local/bin/
+
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=/certs
+# also, ensure the directory pre-exists and has wide enough permissions for "dockerd-entrypoint.sh" to create subdirectories, even when run in "rootless" mode
+RUN mkdir /certs /certs/client && chmod 1777 /certs /certs/client
+# (doing both /certs and /certs/client so that if Docker does a "copy-up" into a volume defined on /certs/client, it will "do the right thing" by default in a way that still works for rootless users)
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh"]

--- a/d/docker/Dockerfiles/20.10_alpine/README.md
+++ b/d/docker/Dockerfiles/20.10_alpine/README.md
@@ -1,10 +1,10 @@
-Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/19.03
+Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/20.10
 
 Docker build command:
-docker build -t ppc64le/docker:19.03.13 .
+docker build -t ppc64le/docker:20.10 .
 
 Docker pull command:
-docker pull ppc64le/docker:19.03.13
+docker pull ppc64le/docker:20.10
 
 Sample Docker run command:
 docker run -it -p some_port:2375 --privileged="true" --name=container_name docker 

--- a/d/docker/Dockerfiles/20.10_alpine/dind-rootless/Dockerfile
+++ b/d/docker/Dockerfiles/20.10_alpine/dind-rootless/Dockerfile
@@ -1,0 +1,52 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM docker:20.10-dind
+
+# busybox "ip" is insufficient:
+#   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
+RUN apk add --no-cache iproute2
+
+# "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+
+# create a default user preconfigured for running rootless dockerd
+RUN set -eux; \
+	adduser -h /home/rootless -g 'Rootless' -D -u 1000 rootless; \
+	echo 'rootless:100000:65536' >> /etc/subuid; \
+	echo 'rootless:100000:65536' >> /etc/subgid
+
+RUN set -eux; \
+	\
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		'x86_64') \
+			url='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.6.tgz'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O rootless.tgz "$url"; \
+	\
+	tar --extract \
+		--file rootless.tgz \
+		--strip-components 1 \
+		--directory /usr/local/bin/ \
+		'docker-rootless-extras/rootlesskit' \
+		'docker-rootless-extras/rootlesskit-docker-proxy' \
+		'docker-rootless-extras/vpnkit' \
+	; \
+	rm rootless.tgz; \
+	\
+	rootlesskit --version; \
+	vpnkit --version
+
+# pre-create "/var/lib/docker" for our rootless user
+RUN set -eux; \
+	mkdir -p /home/rootless/.local/share/docker; \
+	chown -R rootless:rootless /home/rootless/.local/share/docker
+VOLUME /home/rootless/.local/share/docker
+USER rootless

--- a/d/docker/Dockerfiles/20.10_alpine/dind/Dockerfile
+++ b/d/docker/Dockerfiles/20.10_alpine/dind/Dockerfile
@@ -1,0 +1,53 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM ppc64le/docker:20.10.3
+
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN set -eux; \
+	apk add --no-cache \
+		btrfs-progs \
+		e2fsprogs \
+		e2fsprogs-extra \
+		ip6tables \
+		iptables \
+		openssl \
+		shadow-uidmap \
+		xfsprogs \
+		xz \
+# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
+		pigz \
+	; \
+# only install zfs if it's available for the current architecture
+# https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)
+# "apk info XYZ" exits with a zero exit code but no output when the package exists but not for this arch
+	if zfs="$(apk info --no-cache --quiet zfs)" && [ -n "$zfs" ]; then \
+		apk add --no-cache zfs; \
+	fi
+
+# TODO aufs-tools
+
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+RUN set -eux; \
+	addgroup -S dockremap; \
+	adduser -S -G dockremap dockremap; \
+	echo 'dockremap:165536:65536' >> /etc/subuid; \
+	echo 'dockremap:165536:65536' >> /etc/subgid
+
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 42b1175eda071c0e9121e1d64345928384a93df1
+
+RUN set -eux; \
+	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
+	chmod +x /usr/local/bin/dind
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+VOLUME /var/lib/docker
+EXPOSE 2375 2376
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]
+CMD []

--- a/d/docker/Dockerfiles/20.10_alpine/dind/README.md
+++ b/d/docker/Dockerfiles/20.10_alpine/dind/README.md
@@ -1,0 +1,12 @@
+Base Image:
+
+Note - Files have be adapted from community dockerfiles available @ https://github.com/docker-library/docker/tree/835c371c516ebdf67adc0c76bbfb38bf9d3e586c/20.10
+
+We have used ppc64le/docker:20.10 as base image and its not published yet , so build ppc64le/docker:20.10 using Dockerfile available at https://github.com/ppc64le/build-scripts/tree/master/d/docker/20.10_alpine/Dockerfile
+
+Docker build command:
+docker build -t ppc64le/docker:dind-20.10 .
+
+Docker pull command:
+docker pull ppc64le/docker:dind-20.10
+

--- a/d/docker/Dockerfiles/20.10_alpine/dind/dockerd-entrypoint.sh
+++ b/d/docker/Dockerfiles/20.10_alpine/dind/dockerd-entrypoint.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4096
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+# no arguments passed
+# or first arg is `-f` or `--some-option`
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
+	uid="$(id -u)"
+	if [ "$uid" = '0' ]; then
+		dockerSocket='unix:///var/run/docker.sock'
+	else
+		# if we're not root, we must be trying to run rootless
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
+	fi
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
+
+	# add our default arguments
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2376:2376/tcp"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host="$dockerSocket" \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
+	fi
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	find /run /var/run -iname 'docker*.pid' -delete || :
+
+	uid="$(id -u)"
+	if [ "$uid" != '0' ]; then
+		# if we're not root, we must be trying to run rootless
+		if ! command -v rootlesskit > /dev/null; then
+			echo >&2 "error: attempting to run rootless dockerd but missing 'rootlesskit' (perhaps the 'docker:dind-rootless' image variant is intended?)"
+			exit 1
+		fi
+		user="$(id -un 2>/dev/null || :)"
+		if ! grep -qE "^($uid${user:+|$user}):" /etc/subuid || ! grep -qE "^($uid${user:+|$user}):" /etc/subgid; then
+			echo >&2 "error: attempting to run rootless dockerd but missing necessary entries in /etc/subuid and/or /etc/subgid for $uid"
+			exit 1
+		fi
+		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
+		export XDG_RUNTIME_DIR
+		if ! mkdir -p "$XDG_RUNTIME_DIR" || [ ! -w "$XDG_RUNTIME_DIR" ] || ! mkdir -p "$HOME/.local/share/docker" || [ ! -w "$HOME/.local/share/docker" ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need writable HOME ($HOME) and XDG_RUNTIME_DIR ($XDG_RUNTIME_DIR) for user $uid"
+			exit 1
+		fi
+		if [ -f /proc/sys/kernel/unprivileged_userns_clone ] && unprivClone="$(cat /proc/sys/kernel/unprivileged_userns_clone)" && [ "$unprivClone" != '1' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'kernel.unprivileged_userns_clone' (/proc/sys/kernel/unprivileged_userns_clone) set to 1"
+			exit 1
+		fi
+		if [ -f /proc/sys/user/max_user_namespaces ] && maxUserns="$(cat /proc/sys/user/max_user_namespaces)" && [ "$maxUserns" = '0' ]; then
+			echo >&2 "error: attempting to run rootless dockerd but need 'user.max_user_namespaces' (/proc/sys/user/max_user_namespaces) set to a sufficiently large value"
+			exit 1
+		fi
+		# TODO overlay support detection?
+		exec rootlesskit \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--disable-host-loopback \
+			--port-driver=builtin \
+			--copy-up=/etc \
+			--copy-up=/run \
+			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+			"$@"
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
+	fi
+else
+	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too
+	set -- docker-entrypoint.sh "$@"
+fi
+
+exec "$@"

--- a/d/docker/Dockerfiles/20.10_alpine/docker-entrypoint.sh
+++ b/d/docker/Dockerfiles/20.10_alpine/docker-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker help "$1" > /dev/null 2>&1; then
+	set -- docker "$@"
+fi
+
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if we have no DOCKER_HOST but we do have the default Unix socket (standard or rootless), use it explicitly
+if [ -z "${DOCKER_HOST:-}" ] && [ -S /var/run/docker.sock ]; then
+	export DOCKER_HOST=unix:///var/run/docker.sock
+elif [ -z "${DOCKER_HOST:-}" ] && XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" && [ -S "$XDG_RUNTIME_DIR/docker.sock" ]; then
+	export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/docker.sock"
+fi
+
+# if DOCKER_HOST isn't set (no custom setting, no default socket), let's set it to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ "${DOCKER_HOST#tcp:}" != "$DOCKER_HOST" ] \
+	&& [ -z "${DOCKER_TLS_VERIFY:-}" ] \
+	&& [ -z "${DOCKER_CERT_PATH:-}" ] \
+	&& _should_tls \
+; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-docker ... docker:dind ...
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
+exec "$@"

--- a/d/docker/Dockerfiles/20.10_alpine/git/Dockerfile
+++ b/d/docker/Dockerfiles/20.10_alpine/git/Dockerfile
@@ -1,0 +1,9 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM docker:20.10
+
+RUN apk add --no-cache git

--- a/d/docker/Dockerfiles/20.10_alpine/modprobe.sh
+++ b/d/docker/Dockerfiles/20.10_alpine/modprobe.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# "modprobe" without modprobe
+# https://twitter.com/lucabruno/status/902934379835662336
+
+# this isn't 100% fool-proof, but it'll have a much higher success rate than simply using the "real" modprobe
+
+# Docker often uses "modprobe -va foo bar baz"
+# so we ignore modules that start with "-"
+for module; do
+	if [ "${module#-}" = "$module" ]; then
+		ip link show "$module" || true
+		lsmod | grep "$module" || true
+	fi
+done
+
+# remove /usr/local/... from PATH so we can exec the real modprobe as a last resort
+export PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+exec modprobe "$@"


### PR DESCRIPTION
Hi ,

I have used community dockefiles - https://github.com/docker-library/docker/tree/master/19.03 as base and changed these files to install ppc64le rpms for v19.03.13 and done required changes in order to build docker v19.03.13 on Power. Base image changed from alpine to centos8.

1. Docker binary for ppc64le is available till version 18.06.03 https://download.docker.com/linux/static/stable/ppc64le/
2. Docker rpm is available for ppc64le v19.03.x  - https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/

Also in pipelines code I have tested locally build docker:19.03.13 & docker:dind-19.03.13 images in test suite and tests passed. 

dind-sidecar-2s7tq                                                True        Succeeded   5m10s       3m5s

Thanks,
Snehlata Mohite. 