### PR TITLE
Create orc-mapreduce_ubuntu_20.04.sh

### DIFF
--- a/o/orc-mapreduce/LICENSE
+++ b/o/orc-mapreduce/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/o/orc-mapreduce/orc-mapreduce_ubuntu_20.04.sh
+++ b/o/orc-mapreduce/orc-mapreduce_ubuntu_20.04.sh
@@ -1,0 +1,50 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : mapreduce
+# Version       : 1.6
+# Source repo   : https://github.com/apache/orc/tree/master/java/mapreduce
+# Tested on     : ubuntu_20.04
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Gururaj R Katti <Gururaj.Katti@ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION="1.6.7"
+else
+  export VERSION="$1"
+fi
+
+sudo apt-get update
+sudo apt-get install openjdk-8-jdk wget git -y
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-ppc64el/
+
+wget http://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+tar xzvf apache-maven-3.6.3-bin.tar.gz
+export PATH=$PATH:`pwd`/apache-maven-3.6.3/bin
+
+if [ -d "orc" ] ; then
+  rm -rf orc
+fi
+git clone https://github.com/apache/orc
+
+# Build and Test mapreduce
+cd orc/java/mapreduce
+git checkout -b $VERSION rel/release-$VERSION
+ret=$?
+
+if [ $ret -eq 0 ] ; then
+  echo "$Version found to checkout "
+else
+  echo "$Version not found "
+  exit
+fi
+
+mvn clean install


### PR DESCRIPTION
Test result:
[INFO] Results:
[INFO]
[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.0.0:jar (default-jar) @ orc-mapreduce ---
[INFO] Building jar: /home/ubuntu/guru/orc/java/mapreduce/target/orc-mapreduce-1                               .5.5.jar
[INFO]
[INFO] --- maven-site-plugin:3.5.1:attach-descriptor (attach-descriptor) @ orc-m                               apreduce ---
[INFO]
[INFO] --- maven-shade-plugin:3.0.0:shade (default) @ orc-mapreduce ---
[INFO] Excluding org.apache.orc:orc-core:jar:1.5.5 from the shaded jar.
[INFO] Excluding org.apache.orc:orc-shims:jar:1.5.5 from the shaded jar.
[INFO] Including com.google.protobuf:protobuf-java:jar:2.5.0 in the shaded jar.
[INFO] Excluding io.airlift:aircompressor:jar:0.10 from the shaded jar.
[INFO] Excluding javax.xml.bind:jaxb-api:jar:2.2.11 from the shaded jar.
[INFO] Excluding org.apache.hadoop:hadoop-hdfs:jar:2.2.0 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-api:jar:1.7.5 from the shaded jar.
[INFO] Excluding com.esotericsoftware:kryo-shaded:jar:3.0.3 from the shaded jar.
[INFO] Excluding com.esotericsoftware:minlog:jar:1.3.0 from the shaded jar.
[INFO] Excluding org.objenesis:objenesis:jar:2.1 from the shaded jar.
[INFO] Excluding commons-codec:commons-codec:jar:1.4 from the shaded jar.
[INFO] Excluding commons-lang:commons-lang:jar:2.6 from the shaded jar.
[INFO] Excluding com.google.guava:guava:jar:11.0.2 from the shaded jar.
[INFO] Excluding com.google.code.findbugs:jsr305:jar:1.3.9 from the shaded jar.
[INFO] Excluding org.apache.hadoop:hadoop-common:jar:2.2.0 from the shaded jar.
[INFO] Excluding org.apache.hadoop:hadoop-annotations:jar:2.2.0 from the shaded                                jar.
[INFO] Excluding commons-cli:commons-cli:jar:1.3.1 from the shaded jar.
[INFO] Excluding org.apache.commons:commons-math:jar:2.1 from the shaded jar.
[INFO] Excluding xmlenc:xmlenc:jar:0.52 from the shaded jar.
[INFO] Excluding commons-httpclient:commons-httpclient:jar:3.1 from the shaded j                               ar.
[INFO] Excluding commons-io:commons-io:jar:2.1 from the shaded jar.
[INFO] Excluding commons-net:commons-net:jar:3.1 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-core:jar:1.9 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-server:jar:1.9 from the shaded jar.
[INFO] Excluding asm:asm:jar:3.1 from the shaded jar.
[INFO] Excluding commons-logging:commons-logging:jar:1.1.1 from the shaded jar.
[INFO] Excluding log4j:log4j:jar:1.2.17 from the shaded jar.
[INFO] Excluding commons-configuration:commons-configuration:jar:1.6 from the sh                               aded jar.
[INFO] Excluding commons-collections:commons-collections:jar:3.2.1 from the shad                               ed jar.
[INFO] Excluding org.slf4j:slf4j-log4j12:jar:1.7.5 from the shaded jar.
[INFO] Excluding org.codehaus.jackson:jackson-core-asl:jar:1.8.8 from the shaded                                jar.
[INFO] Excluding org.codehaus.jackson:jackson-mapper-asl:jar:1.8.8 from the shad                               ed jar.
[INFO] Excluding org.apache.hadoop:hadoop-auth:jar:2.2.0 from the shaded jar.
[INFO] Excluding com.jcraft:jsch:jar:0.1.42 from the shaded jar.
[INFO] Excluding org.apache.zookeeper:zookeeper:jar:3.4.6 from the shaded jar.
[INFO] Excluding org.apache.commons:commons-compress:jar:1.4.1 from the shaded j                               ar.
[INFO] Excluding org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.2.0 from t                               he shaded jar.
[INFO] Excluding org.apache.hadoop:hadoop-yarn-common:jar:2.2.0 from the shaded                                jar.
[INFO] Excluding org.apache.hadoop:hadoop-yarn-api:jar:2.2.0 from the shaded jar                               .
[INFO] Excluding com.google.inject:guice:jar:3.0 from the shaded jar.
[INFO] Excluding javax.inject:javax.inject:jar:1 from the shaded jar.
[INFO] Excluding aopalliance:aopalliance:jar:1.0 from the shaded jar.
[INFO] Excluding com.sun.jersey.jersey-test-framework:jersey-test-framework-griz                               zly2:jar:1.9 from the shaded jar.
[INFO] Excluding com.sun.jersey.jersey-test-framework:jersey-test-framework-core                               :jar:1.9 from the shaded jar.
[INFO] Excluding javax.servlet:javax.servlet-api:jar:3.0.1 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-client:jar:1.9 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-grizzly2:jar:1.9 from the shaded jar.
[INFO] Excluding org.glassfish.grizzly:grizzly-http:jar:2.1.2 from the shaded ja                               r.
[INFO] Excluding org.glassfish.grizzly:grizzly-framework:jar:2.1.2 from the shad                               ed jar.
[INFO] Excluding org.glassfish.gmbal:gmbal-api-only:jar:3.0.0-b023 from the shad                               ed jar.
[INFO] Excluding org.glassfish.external:management-api:jar:3.0.0-b012 from the s                               haded jar.
[INFO] Excluding org.glassfish.grizzly:grizzly-http-server:jar:2.1.2 from the sh                               aded jar.
[INFO] Excluding org.glassfish.grizzly:grizzly-rcm:jar:2.1.2 from the shaded jar                               .
[INFO] Excluding org.glassfish.grizzly:grizzly-http-servlet:jar:2.1.2 from the s                               haded jar.
[INFO] Excluding org.glassfish:javax.servlet:jar:3.1 from the shaded jar.
[INFO] Excluding com.sun.jersey:jersey-json:jar:1.9 from the shaded jar.
[INFO] Excluding org.codehaus.jettison:jettison:jar:1.1 from the shaded jar.
[INFO] Excluding com.sun.xml.bind:jaxb-impl:jar:2.2.3-1 from the shaded jar.
[INFO] Excluding org.codehaus.jackson:jackson-jaxrs:jar:1.8.3 from the shaded ja                               r.
[INFO] Excluding org.codehaus.jackson:jackson-xc:jar:1.8.3 from the shaded jar.
[INFO] Excluding com.sun.jersey.contribs:jersey-guice:jar:1.9 from the shaded ja                               r.
[INFO] Excluding com.google.inject.extensions:guice-servlet:jar:3.0 from the sha                               ded jar.
[INFO] Excluding io.netty:netty:jar:3.6.2.Final from the shaded jar.
[INFO] Including org.apache.hive:hive-storage-api:jar:2.6.0 in the shaded jar.
[INFO] Attaching shaded artifact.
[INFO]
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ orc-mapreduce                                ---
[INFO] Installing /home/ubuntu/guru/orc/java/mapreduce/target/orc-mapreduce-1.5.                               5.jar to /home/ubuntu/.m2/repository/org/apache/orc/orc-mapreduce/1.5.5/orc-mapr                               educe-1.5.5.jar
[INFO] Installing /home/ubuntu/guru/orc/java/mapreduce/pom.xml to /home/ubuntu/.                               m2/repository/org/apache/orc/orc-mapreduce/1.5.5/orc-mapreduce-1.5.5.pom
[INFO] Installing /home/ubuntu/guru/orc/java/mapreduce/target/orc-mapreduce-1.5.                               5-nohive.jar to /home/ubuntu/.m2/repository/org/apache/orc/orc-mapreduce/1.5.5/o                               rc-mapreduce-1.5.5-nohive.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  28.980 s
[INFO] Finished at: 2021-04-12T11:45:43Z
[INFO] ------------------------------------------------------------------------
ubuntu@gururaj:~/guru$
