### PR TITLE
adding openj9 JVM

### DIFF
--- a/s/strimzi-kafka-oauth/redhat_ubi8/Dockerfile
+++ b/s/strimzi-kafka-oauth/redhat_ubi8/Dockerfile
@@ -1,5 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi
-RUN yum install vim java-1.8.0-openjdk-devel maven git -y
-env JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
-env JRE_HOME=/usr/lib/jvm/java-1.8.0-openjdk/jre
+FROM adoptopenjdk/openjdk8-openj9:ubi 
+RUN yum install maven git -y
 CMD ["bash"]


### PR DESCRIPTION
AMQStreams
Kafka comes with basic OAuth2 support in the form of SASL based authentication module which provides client-server retrieval, exchange and validation of access token used as credentials. For real world usage, extensions have to be provided in the form of JAAS callback handlers which is what Strimzi Kafka OAuth does.

