### PR TITLE
Copy the docker cli

### DIFF
--- a/i/instana-agent-operator/README.md
+++ b/i/instana-agent-operator/README.md
@@ -14,6 +14,7 @@ To build the agent image using the downloaded tarball, please use the following 
 FROM registry.access.redhat.com/ubi8/ubi:8.2
 
 COPY instana-agent-linux-ppcle-64bit.tar.gz /root/
+COPY docker /usr/bin/
 
 RUN yum install -y java-11-openjdk-devel \
     && cd /root/ \

--- a/i/instana-agent-operator/README.md
+++ b/i/instana-agent-operator/README.md
@@ -8,7 +8,7 @@ For platforms other than ppc64le, instana agent in RPM form are available. For p
 
 To build the agent image using the downloaded tarball, please use the following steps:
 
-1. Create a dockerfile in the same directory as the tarball and add the following lines
+1. Create a dockerfile in the same directory as the tarball & docker cli (for ppc) and add the following lines
 
 ```
 FROM registry.access.redhat.com/ubi8/ubi:8.2


### PR DESCRIPTION
This is to fix the issue https://github.com/ppc64le/build-scripts/issues/945

When the agent tries to find the Java version of application's JVM's; it runs docker exec command; however it fails to find docker cli. Below is the error snippet:
----------------------------------------
2021-06-13T14:41:20.497+00:00 | DEBUG | instana-agent-scheduler-thread-2 | ockerProcessImpl | com.instana.agent - 1.1.597 | Running process /usr/lib/jvm/java-11-openjdk-11.0.11.0.9-2.el8_4.ppc64le/bin/java -version via docker exec 675b5fb0e7a60d4d09ab0144c33195436196822703dde73abe4fbecc11fc5c1f
2021-06-13T14:41:20.501+00:00 | DEBUG | instana-agent-scheduler-thread-2 | chineFactoryImpl | com.instana.agent - 1.1.597 | Cannot parse java -version from DockerProcessImpl [pid=47933, parentPid=<lazy>, inContainerPid=1, containerId=675b5fb0e7a60d4d09ab0144c33195436196822703dde73abe4fbecc11fc5c1f, name=java, directory=/, executable=/usr/lib/jvm/java-11-openjdk-11.0.11.0.9-2.el8_4.ppc64le/bin/java, arguments=[-jar, /deployments/app.jar], userName=<lazy>, groupName=<lazy>]
java.io.IOException: Cannot run program "docker": error=2, No such file or directory
----------------------------------------------

To fix this, Docker CLI needs to be copied into PATH. Copying it into /usr/bin directory is fine and works.
Below is the updated dockerfile

`FROM registry.access.redhat.com/ubi8/ubi:8.2

COPY instana-agent-linux-ppcle-64bit.tar.gz /root/
COPY docker /usr/bin/
RUN yum install -y java-11-openjdk-devel \
    && cd /root/ \
    && tar xzf instana-agent-linux-ppcle-64bit.tar.gz \
    && rm -rf instana-agent-linux-ppcle-64bit.tar.gz

ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
    INSTANA_AGENT_MODE="APM" \
    INSTANA_AGENT_KEY="--------------"

CMD ["/root/instana-agent/bin/karaf", "daemon"]`

Make sure to copy the Docker cli in the same folder as that of this dockerfile before building the image.