### PR TITLE
Ramnew exit

### DIFF
--- a/e/exit/LICENSE.txt
+++ b/e/exit/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+© 2021 GitHub, Inc.

--- a/e/exit/node_exit_RHEL_8.4.sh
+++ b/e/exit/node_exit_RHEL_8.4.sh
@@ -1,0 +1,74 @@
+# ----------------------------------------------------------------------------
+#
+# Package		    : exit
+# Version		    : 0.1.2
+# Source repo	  : https://github.com/cowboy/node-exit.git
+# Tested on		  : fedora_8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer	  : Ram K<ramakrishna.s@genisys-group.com>/Priya Seth<sethp@us.ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+
+#!/bin/bash
+
+
+export REPO=https://github.com/cowboy/node-exit.git
+
+#Default tag 0.1.2
+if [ -z "$1" ]; then
+  export VERSION="v0.1.2"
+else
+  export VERSION="$1"
+fi
+
+
+
+#Default installation
+dnf module install nodejs:12
+sudo yum update
+sudo yum install git -y
+
+#For rerunning build
+if [ -d "node-exit" ] ; then
+  rm -rf node-exit
+fi
+
+git clone ${REPO}
+cd node-exit
+git checkout ${VERSION}
+ret=$?
+if [ $ret -eq 0 ] ; then
+  echo  "${VERSION} found to checkout"
+else
+  echo  "${VERSION} not found"
+  exit
+fi
+
+#run the test
+npm install 
+
+npm audit fix --force
+
+npm fund
+ret=$?
+if [ $ret -eq 0 ] ; then
+  echo  "Done build ..."
+else
+  echo  "Failed build......"
+  exit
+fi 
+npm install -g grunt-cli
+npm test
+ret=$?
+if [ $ret -eq 0 ] ; then
+  echo  "Done Test ......"
+else
+  echo  "Failed Test ......"
+fi


### PR DESCRIPTION
HI
Please find the log files below

Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:48:18 ago on Sun Jul 11 15:36:37 2021.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:48:20 ago on Sun Jul 11 15:36:37 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'node-exit'...
remote: Enumerating objects: 133, done.
remote: Total 133 (delta 0), reused 0 (delta 0), pack-reused 133
Receiving objects: 100% (133/133), 39.87 KiB | 680.00 KiB/s, done.
Resolving deltas: 100% (62/62), done.
Note: switching to 'v0.1.2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at e0d68ec Bumping version to v0.1.2.
v0.1.2 found to checkout
npm WARN deprecated nodeunit@0.8.8: you are strongly encouraged to use other testing options
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated coffee-script@1.3.3: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"ppc64"})
npm WARN exit@0.1.2 No license field.

added 498 packages from 308 contributors and audited 500 packages in 15.678s

23 packages are looking for funding
  run `npm fund` for details

found 52 vulnerabilities (14 low, 6 moderate, 32 high)
  run `npm audit fix` to fix them, or `npm audit` for details
npm WARN using --force I sure hope you know what you are doing.
npm WARN grunt-contrib-nodeunit@0.2.2 requires a peer of grunt@~0.4.0 but none is installed. You must install peer dependencies yourself.
npm WARN exit@0.1.2 No license field.

+ grunt-contrib-watch@1.1.0
+ grunt-contrib-jshint@3.0.0
+ grunt@1.4.1
added 87 packages from 84 contributors, removed 18 packages and updated 31 packages in 10.098s

28 packages are looking for funding
  run `npm fund` for details

fixed 52 of 52 vulnerabilities in 500 scanned packages
  3 package updates for 51 vulnerabilities involved breaking changes
  (installed due to `--force` option)
exit@0.1.2
├─┬ https://github.com/sponsors/isaacs
│ └── glob@7.1.7, rimraf@3.0.2, tap@15.0.9, libtap@1.1.1
├─┬ https://github.com/chalk/chalk?sponsor=1
│ └── chalk@4.1.1
├─┬ https://github.com/chalk/ansi-styles?sponsor=1
│ └── ansi-styles@4.3.0
├─┬ https://github.com/sponsors/ljharb
│ └── resolve@1.20.0, is-core-module@2.4.0
├─┬ https://github.com/sponsors/jonschlinkert
│ └── picomatch@2.3.0
├─┬ https://github.com/sponsors/fb55
│ └── domelementtype@2.2.0
├─┬ https://github.com/fb55/entities?sponsor=1
│ └── entities@2.2.0
├─┬ https://github.com/sponsors/feross
│ └── safe-buffer@5.2.1, fromentries@1.3.2
├─┬ https://www.patreon.com/feross
│ └── safe-buffer@5.2.1, fromentries@1.3.2
├─┬ https://feross.org/support
│ └── safe-buffer@5.2.1, fromentries@1.3.2
├─┬ https://github.com/sponsors/epoberezkin
│ └── ajv@6.12.6
├─┬ https://github.com/sponsors/sindresorhus
│ └── make-dir@3.1.0, hasha@5.2.2, p-limit@2.3.0, ansi-escapes@4.3.2, auto-bind@4.0.0, cli-truncate@2.1.0, log-update@3.4.0, type-fest@0.21.3, onetime@5.1.2
├─┬ https://github.com/avajs/find-cache-dir?sponsor=1
│ └── find-cache-dir@3.3.1
├─┬ https://opencollective.com/babel
│ └── @babel/core@7.14.6, @babel/core@7.14.0
└─┬ https://opencollective.com/browserslist
  └── browserslist@4.16.6, caniuse-lite@1.0.30001243


> exit@0.1.2 test /node-exit
> grunt nodeunit

Running "nodeunit:files" (nodeunit) task
Testing exit_test.js......................OK
>> 40 assertions passed (1282ms)

