### PR TITLE
Created antlr-runtime-ubuntu_18.04.sh

### DIFF
--- a/a/antlr-runtime/LICENSE
+++ b/a/antlr-runtime/LICENSE
@@ -199,3 +199,5 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+

--- a/a/antlr-runtime/antlr-runtime-ubuntu_18.04.sh
+++ b/a/antlr-runtime/antlr-runtime-ubuntu_18.04.sh
@@ -1,0 +1,73 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : antlr-runtime-3.4.jar
+# Version       : 3.5.2
+# Source repo   : https://github.com/antlr/antlr3.git
+# Tested on     : Ubuntu_18.04
+# Script License   : Apache License, Version 2 or later
+# Maintainer    : Kishor Kunal Raj <kishore.kunal.mr@ibm.com> / Priya Seth<sethp@us.ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#/bin/bash
+# variables
+JAVA_VER="openjdk-8-jdk"
+PKG_NAME="antlr-runtime"
+LOGS_DIRECTORY=/logs
+REPOSITORY="https://github.com/antlr/antlr3.git"
+
+
+sudo apt update -y
+sudo apt install -y git wget curl unzip nano vim make build-essential
+
+#Setting java environment
+sudo apt install -y ${JAVA_VER}
+jret=$?
+if [ $jret -eq 0 ] ; then
+  echo "Sucessfully installed JDK  ${JAVA_VER} "
+else
+  echo "Failed to install JDK  ${JAVA_VER} "
+  exit
+fi
+
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-ppc64el
+export PATH=$JAVA_HOME/bin:$PATH
+
+#Installing maven
+sudo apt install -y maven
+#export PATH=$PATH:/usr/share/maven/bin
+
+# create folder for saving logs
+sudo mkdir -p /logs
+
+if [ -z "$1" ]; then
+  export PKG_VERSION="master"
+else
+  export PKG_VERSION="$1"
+fi
+
+#For rerunning build
+if [ -d ~/$PKG_NAME-$PKG_VERSION ] ; then
+  sudo rm -rf ~/$PKG_NAME-$PKG_VERSION
+  sudo rm -rf $LOGS_DIRECTORY/$PKG_NAME-$PKG_VERSION.txt
+fi
+
+# clone, build and test specified version
+cd ~
+git clone $REPOSITORY $PKG_NAME-$PKG_VERSION
+cd $PKG_NAME-$PKG_VERSION/
+git checkout -b $PKG_VERSION tags/$PKG_VERSION
+cd runtime/Java/
+sudo mvn install | sudo  tee $LOGS_DIRECTORY/$PKG_NAME-$PKG_VERSION.txt
+ret=$?
+if [ $ret -eq 0 ] ; then
+  echo  "Build successful, log and jar file created....."
+else
+  echo  "Failed to  build......"
+  exit
+fi


### PR DESCRIPTION
Hi,
Created antlr-runtime-ubuntu_18.04.sh. LICENSE file is already available, hence not created. logs can be found below. This PR is in reference to existing PR (https://github.com/ppc64le/build-scripts/pull/923). Creating new PR as by mistake deleted the branch from local repo.  Kindly review

logs
-----
Logs
------
Hit:1 https://dl.winehq.org/wine-builds/ubuntu bionic InRelease
Get:2 https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu bionic InRelease [5,178 B]
Get:3 https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu bionic InRelease [5,142 B]
Err:4 https://dl.bintray.com/sbt/debian  InRelease
  403  Forbidden [IP: 34.212.90.147 443]
Hit:5 http://ports.ubuntu.com/ubuntu-ports bionic InRelease
Get:6 http://ports.ubuntu.com/ubuntu-ports bionic-updates InRelease [88.7 kB]
Hit:7 http://ppa.launchpad.net/beineri/opt-qt562-trusty/ubuntu trusty InRelease
Get:8 http://apt.postgresql.org/pub/repos/apt bionic-pgdg InRelease [110 kB]
Get:9 http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04  InRelease [1,613 B]
Get:10 http://ports.ubuntu.com/ubuntu-ports bionic-backports InRelease [74.6 kB]
Hit:11 http://ppa.launchpad.net/nixnote/nixnote2-stable/ubuntu bionic InRelease
Get:12 http://ports.ubuntu.com/ubuntu-ports bionic-security InRelease [88.7 kB]
Hit:13 http://ppa.launchpad.net/rmescandon/yq/ubuntu bionic InRelease
Get:14 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main ppc64el Packages [1,093 kB]
Get:15 http://apt.postgresql.org/pub/repos/apt bionic-pgdg/main ppc64el Packages [242 kB]
Reading package lists... Done
E: Failed to fetch https://dl.bintray.com/sbt/debian/InRelease  403  Forbidden [IP: 34.212.90.147 443]
E: The repository 'https://dl.bintray.com/sbt/debian  InRelease' is no longer signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
N: Skipping acquire of configured file 'main/binary-ppc64el/Packages' as repository 'https://dl.winehq.org/wine-builds/ubuntu bionic InRelease' doesn't support architecture 'ppc64el'
N: Skipping acquire of configured file 'main/binary-ppc64el/Packages' as repository 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu bionic InRelease' doesn't support architecture 'ppc64el'
N: Skipping acquire of configured file 'main/binary-ppc64el/Packages' as repository 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu bionic InRelease' doesn't support architecture 'ppc64el'
Reading package lists... Done
Building dependency tree
Reading state information... Done
build-essential is already the newest version (12.4ubuntu1).
make is already the newest version (4.1-9.1ubuntu1).
nano is already the newest version (2.9.3-2).
curl is already the newest version (7.58.0-2ubuntu3.13).
git is already the newest version (1:2.17.1-1ubuntu0.8).
unzip is already the newest version (6.0-21ubuntu1.1).
vim is already the newest version (2:8.0.1453-1ubuntu1.4).
wget is already the newest version (1.19.4-1ubuntu2.2).
0 upgraded, 0 newly installed, 0 to remove and 29 not upgraded.
Reading package lists... Done
Building dependency tree
Reading state information... Done
openjdk-8-jdk is already the newest version (8u292-b10-0ubuntu1~18.04).
0 upgraded, 0 newly installed, 0 to remove and 29 not upgraded.
Sucessfully installed JDK  openjdk-8-jdk
Reading package lists... Done
Building dependency tree
Reading state information... Done
maven is already the newest version (3.6.0-1~18.04.1).
0 upgraded, 0 newly installed, 0 to remove and 29 not upgraded.
Cloning into 'antlr-runtime-3.5.2'...
remote: Enumerating objects: 10383, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 10383 (delta 0), reused 0 (delta 0), pack-reused 10380
Receiving objects: 100% (10383/10383), 15.44 MiB | 17.70 MiB/s, done.
Resolving deltas: 100% (6175/6175), done.
Switched to a new branch '3.5.2'
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< org.antlr:antlr-runtime >-----------------------
[INFO] Building ANTLR 3 Runtime 3.5.2
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:1.2:enforce (enforce-maven) @ antlr-runtime ---
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ antlr-runtime ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ antlr-runtime ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 87 source files to /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/target/classes
[WARNING] bootstrap class path not set in conjunction with -source 1.5
[WARNING] source value 1.5 is obsolete and will be removed in a future release
[WARNING] target value 1.5 is obsolete and will be removed in a future release
[WARNING] To suppress warnings about obsolete options, use -Xlint:-options.
[WARNING] /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/main/java/org/antlr/runtime/BitSet.java:[36,8] Class org.antlr.runtime.BitSet overrides equals, but neither it nor any superclass overrides hashCode method
[WARNING] /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/main/java/org/antlr/runtime/SerializedGrammar.java:[66,9] found raw type: java.util.List
  missing type arguments for generic class java.util.List<E>
[WARNING] /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/main/java/org/antlr/runtime/SerializedGrammar.java:[67,22] found raw type: java.util.List
  missing type arguments for generic class java.util.List<E>
[WARNING] /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/main/java/org/antlr/runtime/tree/TreeWizard.java:[232,84] found raw type: java.util.Map
  missing type arguments for generic class java.util.Map<K,V>
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ antlr-runtime ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ antlr-runtime ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 1 source file to /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/target/test-classes
[WARNING] bootstrap class path not set in conjunction with -source 1.6
[INFO]
[INFO] --- maven-surefire-plugin:2.17:test (default-test) @ antlr-runtime ---
[INFO] Surefire report directory: /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.antlr.runtime.TestLookaheadStream
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 sec - in org.antlr.runtime.TestLookaheadStream

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ antlr-runtime ---
[INFO] Building jar: /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/target/antlr-runtime-3.5.2.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ antlr-runtime ---
[INFO] Installing /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/target/antlr-runtime-3.5.2.jar to /root/.m2/repository/org/antlr/antlr-runtime/3.5.2/antlr-runtime-3.5.2.jar
[INFO] Installing /home/ubuntu/antlr-runtime-3.5.2/runtime/Java/pom.xml to /root/.m2/repository/org/antlr/antlr-runtime/3.5.2/antlr-runtime-3.5.2.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.732 s
[INFO] Finished at: 2021-07-13T05:34:35Z
[INFO] ------------------------------------------------------------------------
Build successful, log and jar file created.....

==================================================
Generated jar : ./antlr-ant/main/antlr3-task/antlr3.jar

Regards
Kishor Kunal Raj