### PR TITLE
Adding build script for openapi-schema-validator to UBI

### DIFF
--- a/o/openapi-schema-validator/LICENSE
+++ b/o/openapi-schema-validator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/o/openapi-schema-validator/openapi-schema-validator_ubi_8.3.sh
+++ b/o/openapi-schema-validator/openapi-schema-validator_ubi_8.3.sh
@@ -1,0 +1,67 @@
+# ----------------------------------------------------------------------------
+#
+# Package               : openapi-schema-validator
+# Version               : 0.1.4 & 0.1.5
+# Source repo           : https://github.com/p1c2u/openapi-schema-validator
+# Tested on             : UBI 8.3
+# Script License        : Apache License, Version 2 or later
+# Passing Arguments     : Passing Arguments: 1.Version of package,
+# Script License        : Apache License, Version 2 or later
+# Maintainer            : Arumugam N S <asellappen@yahoo.com> / Priya Seth<sethp@us.ibm.com>
+#
+# Disclaimer            : This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION=master
+else
+  export VERSION=$1
+fi
+
+if [ -d "openapi-schema-validator" ] ; then
+  rm -rf openapi-schema-validator
+fi
+
+# Dependency installation
+
+sudo dnf install python36 -y
+sudo dnf  install -y git  python3-devel
+pip3 install codecov
+
+# Download the repos
+git clone https://github.com/p1c2u/openapi-schema-validator
+
+
+# Build and Test  openapi-schema-validator
+cd openapi-schema-validator
+git checkout $VERSION
+
+ret=$?
+
+if [ $ret -eq 0 ] ; then
+ echo "$Version found to checkout "
+else
+ echo "$Version not found "
+ exit
+fi
+
+#Build and test
+pip3 install -r requirements.txt
+pip3 install -r requirements_dev.txt
+pip3 install -e .
+
+python3.6 setup.py test
+
+ret=$?
+if [ $ret -ne 0 ] ; then
+  echo "Build & Test failed for python 3.6 environment"
+else
+  echo "Build & Test Success for python 3.6 environment"
+fi


### PR DESCRIPTION

Test cases
================

Test 1 :- sh openapi-schema-validator_ubi_8.3.sh

Already on 'master'
Your branch is up to date with 'origin/master'.
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting isodate (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl (45kB)
    100% |████████████████████████████████| 51kB 5.6MB/s
Collecting jsonschema (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 8.3MB/s
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from -r requirements.txt (line 3))
Collecting strict-rfc3339 (from -r requirements.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/56/e4/879ef1dbd6ddea1c77c0078cd59b503368b0456bcca7d063a870ca2119d3/strict-rfc3339-0.7.tar.gz
Collecting rfc3339-validator (from -r requirements.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
Collecting pyrsistent>=0.14.0 (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/f4/d7/0fa558c4fb00f15aabc6d42d365fcca7a15fcc1091cd0f5784a14f390b7f/pyrsistent-0.18.0.tar.gz (104kB)
    100% |████████████████████████████████| 112kB 8.1MB/s
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Collecting attrs>=17.4.0 (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/20/a9/ba6f1cd1a1517ff022b35acd6a7e4246371dfab08b8e42b829b6d07913cc/attrs-21.2.0-py2.py3-none-any.whl (53kB)
    100% |████████████████████████████████| 61kB 8.9MB/s
Collecting importlib-metadata; python_version < "3.8" (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/71/c2/cb1855f0b2a0ae9ccc9b69f150a7aebd4a8d815bd951e74621c4154c52a8/importlib_metadata-4.8.1-py3-none-any.whl
Collecting zipp>=0.5 (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/92/d9/89f433969fb8dc5b9cbdd4b4deb587720ec1aeb59a020cf15002b9593eef/zipp-3.5.0-py3-none-any.whl
Collecting typing-extensions>=3.6.4; python_version < "3.8" (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/74/60/18783336cc7fcdd95dae91d73477830aa53f5d3181ae4fe20491d7fc3199/typing_extensions-3.10.0.2-py3-none-any.whl
Installing collected packages: isodate, pyrsistent, attrs, zipp, typing-extensions, importlib-metadata, jsonschema, strict-rfc3339, rfc3339-validator
  Running setup.py install for pyrsistent ... done
  Running setup.py install for strict-rfc3339 ... done
Successfully installed attrs-21.2.0 importlib-metadata-4.8.1 isodate-0.6.0 jsonschema-3.2.0 pyrsistent-0.18.0 rfc3339-validator-0.1.4 strict-rfc3339-0.7 typing-extensions-3.10.0.2 zipp-3.5.0
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting mock==2.0.0 (from -r requirements_dev.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 5.2MB/s
Collecting pytest==3.5.0 (from -r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/ed/96/271c93f75212c06e2a7ec3e2fa8a9c90acee0a4838dc05bf379ea09aae31/pytest-3.5.0-py2.py3-none-any.whl (194kB)
    100% |████████████████████████████████| 194kB 5.5MB/s
Collecting pytest-flake8 (from -r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/64/ab/bca00e0810b4a1e9a7377b3871529887573d4af47f1674dbe669544944b7/pytest_flake8-1.0.7-py2.py3-none-any.whl
Collecting pytest-cov==2.5.1 (from -r requirements_dev.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/30/7d/7f6a78ae44a1248ee28cc777586c18b28a1df903470e5d34a6e25712b8aa/pytest_cov-2.5.1-py2.py3-none-any.whl
Requirement already satisfied: six>=1.9 in /usr/lib/python3.6/site-packages (from mock==2.0.0->-r requirements_dev.txt (line 1))
Collecting pbr>=0.11 (from mock==2.0.0->-r requirements_dev.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/18/e0/1d4702dd81121d04a477c272d47ee5b6bc970d1a0990b11befa275c55cf2/pbr-5.6.0-py2.py3-none-any.whl (111kB)
    100% |████████████████████████████████| 112kB 9.4MB/s
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Collecting py>=1.5.0 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/67/32/6fe01cfc3d1a27c92fdbcdfc3f67856da8cbadf0dd9f2e18055202b2dc62/py-1.10.0-py2.py3-none-any.whl (97kB)
    100% |████████████████████████████████| 102kB 10.3MB/s
Collecting pluggy<0.7,>=0.5 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
Collecting more-itertools>=4.0.0 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/5d/64/8a2bce13c6a98d3625406ff6b7af9c4891fe3bd9b4bbab8299b387c96276/more_itertools-8.9.0-py3-none-any.whl (51kB)
    100% |████████████████████████████████| 61kB 10.9MB/s
Collecting flake8>=3.5 (from pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/fc/80/35a0716e5d5101e643404dabd20f07f5528a21f3ef4032d31a49c913237b/flake8-3.9.2-py2.py3-none-any.whl (73kB)
    100% |████████████████████████████████| 81kB 10.6MB/s
Requirement already satisfied: coverage>=3.7.1 in /usr/local/lib/python3.6/site-packages (from pytest-cov==2.5.1->-r requirements_dev.txt (line 4))
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Collecting mccabe<0.7.0,>=0.6.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/87/89/479dc97e18549e21354893e4ee4ef36db1d237534982482c3681ee6e7b57/mccabe-0.6.1-py2.py3-none-any.whl
Collecting pyflakes<2.4.0,>=2.3.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/6c/11/2a745612f1d3cbbd9c69ba14b1b43a35a2f5c3c81cd0124508c52c64307f/pyflakes-2.3.1-py2.py3-none-any.whl (68kB)
    100% |████████████████████████████████| 71kB 7.7MB/s
Collecting pycodestyle<2.8.0,>=2.7.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/de/cc/227251b1471f129bc35e966bb0fceb005969023926d744139642d847b7ae/pycodestyle-2.7.0-py2.py3-none-any.whl (41kB)
    100% |████████████████████████████████| 51kB 8.6MB/s
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Installing collected packages: pbr, mock, py, pluggy, more-itertools, pytest, mccabe, pyflakes, pycodestyle, flake8, pytest-flake8, pytest-cov
Successfully installed flake8-3.9.2 mccabe-0.6.1 mock-2.0.0 more-itertools-8.9.0 pbr-5.6.0 pluggy-0.6.0 py-1.10.0 pycodestyle-2.7.0 pyflakes-2.3.1 pytest-3.5.0 pytest-cov-2.5.1 pytest-flake8-1.0.7
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Obtaining file:///root/openapi-schema-validator
Requirement already satisfied: isodate in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: jsonschema>=3.0.0 in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: pyrsistent>=0.14.0 in /usr/local/lib64/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Installing collected packages: openapi-schema-validator
  Running setup.py develop for openapi-schema-validator
Successfully installed openapi-schema-validator
/usr/lib64/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'setup_cfg'
  warnings.warn(msg)
running test
running egg_info
writing openapi_schema_validator.egg-info/PKG-INFO
writing dependency_links to openapi_schema_validator.egg-info/dependency_links.txt
writing requirements to openapi_schema_validator.egg-info/requires.txt
writing top-level names to openapi_schema_validator.egg-info/top_level.txt
reading manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
running build_ext
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-3.5.0, py-1.10.0, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /root/openapi-schema-validator, inifile: setup.cfg
plugins: flake8-1.0.7, cov-2.5.1
collected 28 items

setup.py::FLAKE8 PASSED
openapi_schema_validator/__init__.py::FLAKE8 PASSED
openapi_schema_validator/_format.py::FLAKE8 PASSED
openapi_schema_validator/_types.py::FLAKE8 PASSED
openapi_schema_validator/_validators.py::FLAKE8 PASSED
openapi_schema_validator/shortcuts.py::FLAKE8 PASSED
openapi_schema_validator/validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[f50ec0b7-f960-400d-91f0-c42a6d44e3d0] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[F50EC0B7-F960-400D-91F0-C42A6D44E3D0] PASSED

------------------------------------------------- generated xml file: /root/openapi-schema-validator/reports/junit.xml -------------------------------------------------

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
openapi_schema_validator/__init__.py          9      0   100%
openapi_schema_validator/_format.py          85     30    65%   17-18, 25-26, 33-34, 41, 45, 49, 55, 59, 63-69, 74, 89-95, 100, 103, 109, 130, 137-138, 141
openapi_schema_validator/_types.py            5      0   100%
openapi_schema_validator/_validators.py      59     39    34%   10, 15, 20-21, 25-30, 39-48, 52-67, 71-74, 79-82, 87
openapi_schema_validator/shortcuts.py         8      5    38%   7-11
openapi_schema_validator/validators.py       16      0   100%
-----------------------------------------------------------------------
TOTAL                                       182     74    59%
Coverage XML written to file coverage.xml

====================================================================== 28 passed in 11.04 seconds ======================================================================
Build & Test Success for python 3.6 environment
[root@2568777ab9e5 ~]#


Test 2:-

 sh openapi-schema-validator_ubi_8.3.sh  0.1.4


Cloning into 'openapi-schema-validator'...
remote: Enumerating objects: 169, done.
remote: Counting objects: 100% (169/169), done.
remote: Compressing objects: 100% (115/115), done.
remote: Total 169 (delta 81), reused 106 (delta 36), pack-reused 0
Receiving objects: 100% (169/169), 31.64 KiB | 7.91 MiB/s, done.
Resolving deltas: 100% (81/81), done.
Note: switching to '0.1.4'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at a1e3459 Version 0.1.4
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting isodate (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl (45kB)
    100% |████████████████████████████████| 51kB 5.2MB/s
Collecting jsonschema (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 8.0MB/s
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from -r requirements.txt (line 3))
Collecting strict-rfc3339 (from -r requirements.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/56/e4/879ef1dbd6ddea1c77c0078cd59b503368b0456bcca7d063a870ca2119d3/strict-rfc3339-0.7.tar.gz
Collecting rfc3339-validator (from -r requirements.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Collecting attrs>=17.4.0 (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/20/a9/ba6f1cd1a1517ff022b35acd6a7e4246371dfab08b8e42b829b6d07913cc/attrs-21.2.0-py2.py3-none-any.whl (53kB)
    100% |████████████████████████████████| 61kB 8.2MB/s
Collecting pyrsistent>=0.14.0 (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/f4/d7/0fa558c4fb00f15aabc6d42d365fcca7a15fcc1091cd0f5784a14f390b7f/pyrsistent-0.18.0.tar.gz (104kB)
    100% |████████████████████████████████| 112kB 8.1MB/s
Collecting importlib-metadata; python_version < "3.8" (from jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/71/c2/cb1855f0b2a0ae9ccc9b69f150a7aebd4a8d815bd951e74621c4154c52a8/importlib_metadata-4.8.1-py3-none-any.whl
Collecting zipp>=0.5 (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/92/d9/89f433969fb8dc5b9cbdd4b4deb587720ec1aeb59a020cf15002b9593eef/zipp-3.5.0-py3-none-any.whl
Collecting typing-extensions>=3.6.4; python_version < "3.8" (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/74/60/18783336cc7fcdd95dae91d73477830aa53f5d3181ae4fe20491d7fc3199/typing_extensions-3.10.0.2-py3-none-any.whl
Installing collected packages: isodate, attrs, pyrsistent, zipp, typing-extensions, importlib-metadata, jsonschema, strict-rfc3339, rfc3339-validator
  Running setup.py install for pyrsistent ... done
  Running setup.py install for strict-rfc3339 ... done
Successfully installed attrs-21.2.0 importlib-metadata-4.8.1 isodate-0.6.0 jsonschema-3.2.0 pyrsistent-0.18.0 rfc3339-validator-0.1.4 strict-rfc3339-0.7 typing-extensions-3.10.0.2 zipp-3.5.0
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting mock==2.0.0 (from -r requirements_dev.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/e6/35/f187bdf23be87092bd0f1200d43d23076cee4d0dec109f195173fd3ebc79/mock-2.0.0-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 5.2MB/s
Collecting pytest==3.5.0 (from -r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/ed/96/271c93f75212c06e2a7ec3e2fa8a9c90acee0a4838dc05bf379ea09aae31/pytest-3.5.0-py2.py3-none-any.whl (194kB)
    100% |████████████████████████████████| 194kB 5.4MB/s
Collecting pytest-flake8 (from -r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/64/ab/bca00e0810b4a1e9a7377b3871529887573d4af47f1674dbe669544944b7/pytest_flake8-1.0.7-py2.py3-none-any.whl
Collecting pytest-cov==2.5.1 (from -r requirements_dev.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/30/7d/7f6a78ae44a1248ee28cc777586c18b28a1df903470e5d34a6e25712b8aa/pytest_cov-2.5.1-py2.py3-none-any.whl
Requirement already satisfied: six>=1.9 in /usr/lib/python3.6/site-packages (from mock==2.0.0->-r requirements_dev.txt (line 1))
Collecting pbr>=0.11 (from mock==2.0.0->-r requirements_dev.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/18/e0/1d4702dd81121d04a477c272d47ee5b6bc970d1a0990b11befa275c55cf2/pbr-5.6.0-py2.py3-none-any.whl (111kB)
    100% |████████████████████████████████| 112kB 9.2MB/s
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Collecting py>=1.5.0 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/67/32/6fe01cfc3d1a27c92fdbcdfc3f67856da8cbadf0dd9f2e18055202b2dc62/py-1.10.0-py2.py3-none-any.whl (97kB)
    100% |████████████████████████████████| 102kB 9.9MB/s
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Collecting pluggy<0.7,>=0.5 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/ba/65/ded3bc40bbf8d887f262f150fbe1ae6637765b5c9534bd55690ed2c0b0f7/pluggy-0.6.0-py3-none-any.whl
Collecting more-itertools>=4.0.0 (from pytest==3.5.0->-r requirements_dev.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/5d/64/8a2bce13c6a98d3625406ff6b7af9c4891fe3bd9b4bbab8299b387c96276/more_itertools-8.9.0-py3-none-any.whl (51kB)
    100% |████████████████████████████████| 61kB 10.8MB/s
Collecting flake8>=3.5 (from pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/fc/80/35a0716e5d5101e643404dabd20f07f5528a21f3ef4032d31a49c913237b/flake8-3.9.2-py2.py3-none-any.whl (73kB)
    100% |████████████████████████████████| 81kB 10.4MB/s
Requirement already satisfied: coverage>=3.7.1 in /usr/local/lib/python3.6/site-packages (from pytest-cov==2.5.1->-r requirements_dev.txt (line 4))
Collecting pyflakes<2.4.0,>=2.3.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/6c/11/2a745612f1d3cbbd9c69ba14b1b43a35a2f5c3c81cd0124508c52c64307f/pyflakes-2.3.1-py2.py3-none-any.whl (68kB)
    100% |████████████████████████████████| 71kB 9.9MB/s
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Collecting pycodestyle<2.8.0,>=2.7.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/de/cc/227251b1471f129bc35e966bb0fceb005969023926d744139642d847b7ae/pycodestyle-2.7.0-py2.py3-none-any.whl (41kB)
    100% |████████████████████████████████| 51kB 10.9MB/s
Collecting mccabe<0.7.0,>=0.6.0 (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/87/89/479dc97e18549e21354893e4ee4ef36db1d237534982482c3681ee6e7b57/mccabe-0.6.1-py2.py3-none-any.whl
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Installing collected packages: pbr, mock, py, pluggy, more-itertools, pytest, pyflakes, pycodestyle, mccabe, flake8, pytest-flake8, pytest-cov
Successfully installed flake8-3.9.2 mccabe-0.6.1 mock-2.0.0 more-itertools-8.9.0 pbr-5.6.0 pluggy-0.6.0 py-1.10.0 pycodestyle-2.7.0 pyflakes-2.3.1 pytest-3.5.0 pytest-cov-2.5.1 pytest-flake8-1.0.7
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Obtaining file:///root/openapi-schema-validator
Requirement already satisfied: isodate in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.4)
Requirement already satisfied: jsonschema>=3.0.0 in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.4)
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from openapi-schema-validator==0.1.4)
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Requirement already satisfied: pyrsistent>=0.14.0 in /usr/local/lib64/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.4)
Installing collected packages: openapi-schema-validator
  Running setup.py develop for openapi-schema-validator
Successfully installed openapi-schema-validator
/usr/lib64/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'setup_cfg'
  warnings.warn(msg)
running test
running egg_info
writing openapi_schema_validator.egg-info/PKG-INFO
writing dependency_links to openapi_schema_validator.egg-info/dependency_links.txt
writing requirements to openapi_schema_validator.egg-info/requires.txt
writing top-level names to openapi_schema_validator.egg-info/top_level.txt
reading manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
running build_ext
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-3.5.0, py-1.10.0, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /root/openapi-schema-validator, inifile: setup.cfg
plugins: flake8-1.0.7, cov-2.5.1
collected 28 items

setup.py::FLAKE8 PASSED
openapi_schema_validator/__init__.py::FLAKE8 PASSED
openapi_schema_validator/_format.py::FLAKE8 PASSED
openapi_schema_validator/_types.py::FLAKE8 PASSED
openapi_schema_validator/_validators.py::FLAKE8 PASSED
openapi_schema_validator/shortcuts.py::FLAKE8 PASSED
openapi_schema_validator/validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[f50ec0b7-f960-400d-91f0-c42a6d44e3d0] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[F50EC0B7-F960-400D-91F0-C42A6D44E3D0] PASSED

------------------------------------------------- generated xml file: /root/openapi-schema-validator/reports/junit.xml -------------------------------------------------

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
openapi_schema_validator/__init__.py          9      0   100%
openapi_schema_validator/_format.py          85     30    65%   17-18, 25-26, 33-34, 41, 45, 49, 55, 59, 63-69, 74, 89-95, 100, 103, 109, 130, 137-138, 141
openapi_schema_validator/_types.py            5      0   100%
openapi_schema_validator/_validators.py      59     39    34%   10, 15, 20-21, 25-30, 39-48, 52-67, 71-74, 79-82, 87
openapi_schema_validator/shortcuts.py         8      5    38%   7-11
openapi_schema_validator/validators.py       16      0   100%
-----------------------------------------------------------------------
TOTAL                                       182     74    59%
Coverage XML written to file coverage.xml

====================================================================== 28 passed in 10.97 seconds ======================================================================
Build & Test Success for python 3.6 environment
[root@a3f4045bfe83 ~]#

Test 3:
sh openapi-schema-validator_ubi_8.3.sh  0.1.5


HEAD is now at 89fea04 Version 0.1.5
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already satisfied: isodate in /usr/local/lib/python3.6/site-packages (from -r requirements.txt (line 1))
Requirement already satisfied: jsonschema in /usr/local/lib/python3.6/site-packages (from -r requirements.txt (line 2))
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from -r requirements.txt (line 3))
Requirement already satisfied: strict-rfc3339 in /usr/local/lib/python3.6/site-packages (from -r requirements.txt (line 4))
Requirement already satisfied: rfc3339-validator in /usr/local/lib/python3.6/site-packages (from -r requirements.txt (line 5))
Requirement already satisfied: pyrsistent>=0.14.0 in /usr/local/lib64/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from jsonschema->-r requirements.txt (line 2))
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema->-r requirements.txt (line 2))
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already satisfied: mock==2.0.0 in /usr/local/lib/python3.6/site-packages (from -r requirements_dev.txt (line 1))
Requirement already satisfied: pytest==3.5.0 in /usr/local/lib/python3.6/site-packages (from -r requirements_dev.txt (line 2))
Requirement already satisfied: pytest-flake8 in /usr/local/lib/python3.6/site-packages (from -r requirements_dev.txt (line 3))
Requirement already satisfied: pytest-cov==2.5.1 in /usr/local/lib/python3.6/site-packages (from -r requirements_dev.txt (line 4))
Requirement already satisfied: six>=1.9 in /usr/lib/python3.6/site-packages (from mock==2.0.0->-r requirements_dev.txt (line 1))
Requirement already satisfied: pbr>=0.11 in /usr/local/lib/python3.6/site-packages (from mock==2.0.0->-r requirements_dev.txt (line 1))
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: py>=1.5.0 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: more-itertools>=4.0.0 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: pluggy<0.7,>=0.5 in /usr/local/lib/python3.6/site-packages (from pytest==3.5.0->-r requirements_dev.txt (line 2))
Requirement already satisfied: flake8>=3.5 in /usr/local/lib/python3.6/site-packages (from pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: coverage>=3.7.1 in /usr/local/lib/python3.6/site-packages (from pytest-cov==2.5.1->-r requirements_dev.txt (line 4))
Requirement already satisfied: mccabe<0.7.0,>=0.6.0 in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: pyflakes<2.4.0,>=2.3.0 in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: pycodestyle<2.8.0,>=2.7.0 in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->flake8>=3.5->pytest-flake8->-r requirements_dev.txt (line 3))
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Obtaining file:///root/openapi-schema-validator
Requirement already satisfied: isodate in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: jsonschema>=3.0.0 in /usr/local/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from openapi-schema-validator==0.1.5)
Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: importlib-metadata; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: pyrsistent>=0.14.0 in /usr/local/lib64/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/site-packages (from jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->jsonschema>=3.0.0->openapi-schema-validator==0.1.5)
Installing collected packages: openapi-schema-validator
  Found existing installation: openapi-schema-validator 0.1.5
    Can't uninstall 'openapi-schema-validator'. No files were found to uninstall.
  Running setup.py develop for openapi-schema-validator
Successfully installed openapi-schema-validator
/usr/lib64/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'setup_cfg'
  warnings.warn(msg)
running test
running egg_info
writing openapi_schema_validator.egg-info/PKG-INFO
writing dependency_links to openapi_schema_validator.egg-info/dependency_links.txt
writing requirements to openapi_schema_validator.egg-info/requires.txt
writing top-level names to openapi_schema_validator.egg-info/top_level.txt
reading manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'openapi_schema_validator.egg-info/SOURCES.txt'
running build_ext
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-3.5.0, py-1.10.0, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /root/openapi-schema-validator, inifile: setup.cfg
plugins: flake8-1.0.7, cov-2.5.1
collected 28 items

setup.py::FLAKE8 PASSED
openapi_schema_validator/__init__.py::FLAKE8 PASSED
openapi_schema_validator/_format.py::FLAKE8 PASSED
openapi_schema_validator/_types.py::FLAKE8 PASSED
openapi_schema_validator/_validators.py::FLAKE8 PASSED
openapi_schema_validator/shortcuts.py::FLAKE8 PASSED
openapi_schema_validator/validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::FLAKE8 PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_null[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[boolean] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[array] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[integer] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[number] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_nullable[string] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_no_datetime_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_rfc3339_validator[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_strict_rfc3339[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[1989-01-02T00:00:00Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_format_datetime_isodate[2018-01-02T23:59:59Z] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[f50ec0b7-f960-400d-91f0-c42a6d44e3d0] PASSED
tests/integration/test_validators.py::TestOAS30ValidatorValidate::test_string_uuid[F50EC0B7-F960-400D-91F0-C42A6D44E3D0] PASSED

------------------------------------------------- generated xml file: /root/openapi-schema-validator/reports/junit.xml -------------------------------------------------

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
openapi_schema_validator/__init__.py          9      0   100%
openapi_schema_validator/_format.py          85     30    65%   17-18, 25-26, 33-34, 41, 45, 49, 55, 59, 63-69, 74, 89-95, 100, 103, 109, 130, 137-138, 141
openapi_schema_validator/_types.py            5      0   100%
openapi_schema_validator/_validators.py      59     39    34%   10, 15, 20-21, 25-30, 39-48, 52-67, 71-74, 79-82, 87
openapi_schema_validator/shortcuts.py         8      5    38%   7-11
openapi_schema_validator/validators.py       16      0   100%
-----------------------------------------------------------------------
TOTAL                                       182     74    59%
Coverage XML written to file coverage.xml

====================================================================== 28 passed in 11.01 seconds ======================================================================
Build & Test Success for python 3.6 environment

