### PR TITLE
Create pep517_ubi_8.4.sh

### DIFF
--- a/p/pep517/LICENSE
+++ b/p/pep517/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/p/pep517/pep517_ubi_8.4.sh
+++ b/p/pep517/pep517_ubi_8.4.sh
@@ -1,0 +1,60 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : pep517
+# Version       : v0.11.0, v0.10.0
+# Source repo   : https://github.com/pypa/pep517
+# Tested on     : UBI 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Gururaj R Katti <Gururaj.Katti@ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION=master
+else
+  export VERSION=$1
+fi
+
+if [ -d "pep517" ] ; then
+  rm -rf pep517
+fi
+
+# Dependency installation
+sudo dnf install -y python36
+sudo dnf install -y git
+sudo dnf install -y wget
+
+# Download the repos
+git clone https://github.com/pypa/pep517
+
+
+# Build and Test pep517
+cd pep517
+git checkout $VERSION
+
+ret=$?
+
+if [ $ret -eq 0 ] ; then
+ echo "$Version found to checkout "
+else
+ echo "$Version not found "
+ exit
+fi
+
+sudo pip3 install tox
+
+ret=$?
+
+if [ $ret -ne 0 ] ; then
+ echo "dependency python pkg install failed "
+ exit
+else
+  tox -e py36
+fi


### PR DESCRIPTION
1. Without argument
[testw@cf883d5d5ee3 ~]$ ./pep517_ubi_8.4.sh
.....
.....
collected 67 items

doc/conf.py .                                                            [  1%]
pep517/__init__.py .                                                     [  2%]
pep517/build.py .                                                        [  4%]
pep517/check.py .                                                        [  5%]
pep517/colorlog.py .                                                     [  7%]
pep517/compat.py .                                                       [  8%]
pep517/dirtools.py .                                                     [ 10%]
pep517/envbuild.py .                                                     [ 11%]
pep517/meta.py .                                                         [ 13%]
pep517/wrappers.py .                                                     [ 14%]
pep517/in_process/__init__.py .                                          [ 16%]
pep517/in_process/_in_process.py .                                       [ 17%]
tests/__init__.py .                                                      [ 19%]
tests/test_build.py ....                                                 [ 25%]
tests/test_call_hooks.py ................                                [ 49%]
tests/test_envbuild.py ...                                               [ 53%]
tests/test_hook_fallbacks.py .........                                   [ 67%]
tests/test_inplace_hooks.py .........                                    [ 80%]
tests/test_meta.py ....                                                  [ 86%]
tests/samples/buildsys_pkgs/buildsys.py .                                [ 88%]
tests/samples/buildsys_pkgs/buildsys_minimal.py .                        [ 89%]
tests/samples/buildsys_pkgs/buildsys_minimal_editable.py .               [ 91%]
tests/samples/pkg1/pkg1.py .                                             [ 92%]
tests/samples/pkg2/pkg2.py .                                             [ 94%]
tests/samples/pkg3/pkg3.py .                                             [ 95%]
tests/samples/pkg_intree/backend/intree_backend.py .                     [ 97%]
tests/samples/setup-py/setup.py .                                        [ 98%]
tests/samples/test-for-issue-104/setup.py .                              [100%]

============================= 67 passed in 14.60s ==============================
___________________________________ summary ____________________________________
  py36: commands succeeded
  congratulations :)
[testw@cf883d5d5ee3 ~]$
2. With valid argument
[testw@cf883d5d5ee3 ~]$ ./pep517_ubi_8.4.sh v0.10.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:05:21 ago on Tue Sep  7 06:10:17 2021.
Package python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:05:23 ago on Tue Sep  7 06:10:17 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:05:25 ago on Tue Sep  7 06:10:17 2021.
Package wget-1.19.5-10.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'pep517'...
remote: Enumerating objects: 1123, done.
remote: Counting objects: 100% (276/276), done.
remote: Compressing objects: 100% (183/183), done.
remote: Total 1123 (delta 156), reused 182 (delta 85), pack-reused 847
Receiving objects: 100% (1123/1123), 212.07 KiB | 1.24 MiB/s, done.
Resolving deltas: 100% (660/660), done.
Note: switching to 'v0.10.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 6e9ab97 Bump version: 0.9.1 → 0.10.0
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already satisfied: tox in /usr/local/lib/python3.6/site-packages
Requirement already satisfied: six>=1.14.0 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: py>=1.4.17 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: pluggy>=0.12.0 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: filelock>=3.0.0 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: packaging>=14 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: importlib-metadata>=0.12; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: toml>=0.9.4 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0 in /usr/local/lib/python3.6/site-packages (from tox)
Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.6/site-packages (from packaging>=14->tox)
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata>=0.12; python_version < "3.8"->tox)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata>=0.12; python_version < "3.8"->tox)
Requirement already satisfied: platformdirs<3,>=2 in /usr/local/lib/python3.6/site-packages (from virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0->tox)
Requirement already satisfied: importlib-resources>=1.0; python_version < "3.7" in /usr/local/lib/python3.6/site-packages (from virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0->tox)
Requirement already satisfied: backports.entry-points-selectable>=1.0.4 in /usr/local/lib/python3.6/site-packages (from virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0->tox)
Requirement already satisfied: distlib<1,>=0.3.1 in /usr/local/lib/python3.6/site-packages (from virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0->tox)
py36 create: /home/testw/pep517/.tox/py36
py36 installdeps: -rdev-requirements.txt
py36 installed: attrs==21.2.0,flake8==3.9.2,importlib-metadata==4.8.1,iniconfig==1.1.1,mccabe==0.6.1,packaging==21.0,pluggy==1.0.0,py==1.10.0,pycodestyle==2.7.0,pyflakes==2.3.1,pyparsing==2.4.7,pytest==6.2.5,pytest-flake8==1.0.7,testpath==0.5.0,toml==0.10.2,typing-extensions==3.10.0.2,zipp==3.5.0
py36 run-test-pre: PYTHONHASHSEED='807757770'
py36 run-test: commands[0] | pytest
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
cachedir: .tox/py36/.pytest_cache
rootdir: /home/testw/pep517, configfile: pytest.ini
plugins: flake8-1.0.7
collected 56 items

doc/conf.py .                                                            [  1%]
pep517/__init__.py .                                                     [  3%]
pep517/build.py .                                                        [  5%]
pep517/check.py .                                                        [  7%]
pep517/colorlog.py .                                                     [  8%]
pep517/compat.py .                                                       [ 10%]
pep517/dirtools.py .                                                     [ 12%]
pep517/envbuild.py .                                                     [ 14%]
pep517/meta.py .                                                         [ 16%]
pep517/wrappers.py .                                                     [ 17%]
pep517/in_process/__init__.py .                                          [ 19%]
pep517/in_process/_in_process.py .                                       [ 21%]
tests/__init__.py .                                                      [ 23%]
tests/test_build.py ....                                                 [ 30%]
tests/test_call_hooks.py ............                                    [ 51%]
tests/test_envbuild.py ...                                               [ 57%]
tests/test_hook_fallbacks.py .....                                       [ 66%]
tests/test_inplace_hooks.py .........                                    [ 82%]
tests/test_meta.py ....                                                  [ 89%]
tests/samples/buildsys_pkgs/buildsys.py .                                [ 91%]
tests/samples/buildsys_pkgs/buildsys_minimal.py .                        [ 92%]
tests/samples/pkg1/pkg1.py .                                             [ 94%]
tests/samples/pkg2/pkg2.py .                                             [ 96%]
tests/samples/pkg_intree/backend/intree_backend.py .                     [ 98%]
tests/samples/test-for-issue-104/setup.py .                              [100%]

=============================== warnings summary ===============================
doc/conf.py: 2 warnings
pep517/__init__.py: 2 warnings
pep517/build.py: 2 warnings
pep517/check.py: 2 warnings
pep517/colorlog.py: 2 warnings
pep517/compat.py: 2 warnings
pep517/dirtools.py: 2 warnings
pep517/envbuild.py: 2 warnings
pep517/meta.py: 2 warnings
pep517/wrappers.py: 2 warnings
pep517/in_process/__init__.py: 2 warnings
pep517/in_process/_in_process.py: 2 warnings
tests/__init__.py: 2 warnings
tests/test_build.py: 2 warnings
tests/test_call_hooks.py: 2 warnings
tests/test_envbuild.py: 2 warnings
tests/test_hook_fallbacks.py: 2 warnings
tests/test_inplace_hooks.py: 2 warnings
tests/test_meta.py: 2 warnings
tests/samples/buildsys_pkgs/buildsys.py: 2 warnings
tests/samples/buildsys_pkgs/buildsys_minimal.py: 2 warnings
tests/samples/pkg1/pkg1.py: 2 warnings
tests/samples/pkg2/pkg2.py: 2 warnings
tests/samples/pkg_intree/backend/intree_backend.py: 2 warnings
tests/samples/test-for-issue-104/setup.py: 2 warnings
  /home/testw/pep517/.tox/py36/lib/python3.6/site-packages/flake8/plugins/manager.py:254: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    eps = importlib_metadata.entry_points().get(self.namespace, ())

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================= 56 passed, 50 warnings in 14.92s =======================
___________________________________ summary ____________________________________
  py36: commands succeeded
  congratulations :)
[testw@cf883d5d5ee3 ~]$
3. With invalid argument
[testw@cf883d5d5ee3 ~]$ ./pep517_ubi_8.4.sh v0.12.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:06:43 ago on Tue Sep  7 06:10:17 2021.
Package python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:06:45 ago on Tue Sep  7 06:10:17 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:06:46 ago on Tue Sep  7 06:10:17 2021.
Package wget-1.19.5-10.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'pep517'...
remote: Enumerating objects: 1123, done.
remote: Counting objects: 100% (276/276), done.
remote: Compressing objects: 100% (183/183), done.
remote: Total 1123 (delta 156), reused 182 (delta 85), pack-reused 847
Receiving objects: 100% (1123/1123), 212.07 KiB | 1.62 MiB/s, done.
Resolving deltas: 100% (660/660), done.
error: pathspec 'v0.12.0' did not match any file(s) known to git
 not found
[testw@cf883d5d5ee3 ~]$