### PR TITLE
 Adding build script for executing on UBI

### DIFF
--- a/e/executing/LICENSE.txt
+++ b/e/executing/LICENSE.txt
@@ -1,0 +1,201 @@
+ Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/e/executing/executing_ubi_8.3.sh
+++ b/e/executing/executing_ubi_8.3.sh
@@ -1,0 +1,83 @@
+# ----------------------------------------------------------------------------
+#
+# Package               : executing
+# Version               : 0.6.0
+# Source repo           : https://github.com/alexmojaki/executing
+# Tested on             : UBI 8.3
+# Script License        : Apache License, Version 2 or later
+# Passing Arguments     : Passing Arguments: 1.Version of package,
+# Script License        : Apache License, Version 2 or later
+# Maintainer            : Arumugam N S <asellappen@yahoo.com> / Priya Seth<sethp@us.ibm.com>
+#
+# Disclaimer            : This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION=master
+else
+  export VERSION=$1
+fi
+
+if [ -d "executing" ] ; then
+  rm -rf executing
+fi
+
+# Dependency installation
+
+sudo dnf install python36 -y
+sudo dnf  install -y git  python3-devel
+
+# Download the repos
+git clone https://github.com/alexmojaki/executing
+
+
+# Build and Test executing
+cd executing
+git checkout $VERSION
+
+ret=$?
+
+if [ $ret -eq 0 ] ; then
+ echo "$Version found to checkout "
+else
+ echo "$Version not found "
+ exit
+fi
+
+pip3 install codecov
+pip3 install --upgrade coveralls asttokens pytest setuptools setuptools_scm pep517
+pip3 install -e .
+
+
+#Build and test with differnt python environments
+python3.6 setup.py test
+
+ret=$?
+if [ $ret -ne 0 ] ; then
+  echo "Build & Test failed for python 3.6 environment"
+else
+  echo "Build & Test Success for python 3.6 environment"
+fi
+
+
+#coverage  test
+
+coverage run --include=executing/executing.py --append -m pytest tests/test_pytest.py
+
+ret=$?
+if [ $ret -ne 0 ] ; then
+  echo "coverage Test failed for python 3.6 environment"
+else
+  echo "coverage Test Success for python 3.6 environment"
+fi
+
+#coverage  report
+
+coverage report -m


### PR DESCRIPTION
Test 1:
sh executing_ubi_8.3.sh 

Cloning into 'executing'...
remote: Enumerating objects: 905, done.
remote: Counting objects: 100% (236/236), done.
remote: Compressing objects: 100% (133/133), done.
remote: Total 905 (delta 116), reused 168 (delta 71), pack-reused 669
Receiving objects: 100% (905/905), 634.64 KiB | 2.61 MiB/s, done.
Resolving deltas: 100% (552/552), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting codecov
  Downloading https://files.pythonhosted.org/packages/dc/e2/964d0881eff5a67bf5ddaea79a13c7b34a74bc4efe917b368830b475a0b9/codecov-2.1.12-py2.py3-none-any.whl
Collecting coverage (from codecov)
  Downloading https://files.pythonhosted.org/packages/38/df/d5e67851e83948def768d7fb1a0fd373665b20f56ff63ed220c6cd16cb11/coverage-5.5.tar.gz (691kB)
    100% |████████████████████████████████| 696kB 1.7MB/s
Requirement already satisfied: requests>=2.7.9 in /usr/lib/python3.6/site-packages (from codecov)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Requirement already satisfied: idna<2.8,>=2.5 in /usr/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Requirement already satisfied: urllib3<1.25,>=1.21.1 in /usr/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Installing collected packages: coverage, codecov
  Running setup.py install for coverage ... done
Successfully installed codecov-2.1.12 coverage-5.5
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting coveralls
  Downloading https://files.pythonhosted.org/packages/23/a5/64ef61a05dca7295c54d29707506f0269424379c518a344bccce9601c52b/coveralls-3.2.0-py2.py3-none-any.whl
Collecting asttokens
  Downloading https://files.pythonhosted.org/packages/16/d5/b0ad240c22bba2f4591693b0ca43aae94fbd77fb1e2b107d54fff1462b6f/asttokens-2.0.5-py2.py3-none-any.whl
Collecting pytest
  Downloading https://files.pythonhosted.org/packages/40/76/86f886e750b81a4357b6ed606b2bcf0ce6d6c27ad3c09ebf63ed674fc86e/pytest-6.2.5-py3-none-any.whl (280kB)
    100% |████████████████████████████████| 286kB 4.0MB/s
Collecting setuptools
  Downloading https://files.pythonhosted.org/packages/56/0f/52135ff086dd42b10636a205170f50a0a8dcd0d648835abdd3a8c0bc06ac/setuptools-58.0.2-py3-none-any.whl (816kB)
    100% |████████████████████████████████| 819kB 1.5MB/s
Collecting setuptools_scm
  Downloading https://files.pythonhosted.org/packages/63/c1/222d695c331e6d40c6ec8676e366f5c6db947c9321448ca336b4456ee2ff/setuptools_scm-6.3.1-py3-none-any.whl
Collecting pep517
  Downloading https://files.pythonhosted.org/packages/3b/da/bfa8de153f54df0b04ca634a4489d28758ab56b394931588627fcb49f44b/pep517-0.11.0-py2.py3-none-any.whl
Collecting requests>=1.0.0 (from coveralls)
  Downloading https://files.pythonhosted.org/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl (62kB)
    100% |████████████████████████████████| 71kB 10.9MB/s
Collecting docopt>=0.6.1 (from coveralls)
  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
Requirement already up-to-date: coverage<6.0,>=4.1 in /usr/local/lib/python3.6/site-packages (from coveralls)
Collecting six (from asttokens)
  Downloading https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
Collecting pluggy<2.0,>=0.12 (from pytest)
  Downloading https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl
Collecting attrs>=19.2.0 (from pytest)
  Downloading https://files.pythonhosted.org/packages/20/a9/ba6f1cd1a1517ff022b35acd6a7e4246371dfab08b8e42b829b6d07913cc/attrs-21.2.0-py2.py3-none-any.whl (53kB)
    100% |████████████████████████████████| 61kB 10.6MB/s
Collecting py>=1.8.2 (from pytest)
  Downloading https://files.pythonhosted.org/packages/67/32/6fe01cfc3d1a27c92fdbcdfc3f67856da8cbadf0dd9f2e18055202b2dc62/py-1.10.0-py2.py3-none-any.whl (97kB)
    100% |████████████████████████████████| 102kB 10.2MB/s
Collecting toml (from pytest)
  Downloading https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
Collecting iniconfig (from pytest)
  Downloading https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl
Collecting importlib-metadata>=0.12; python_version < "3.8" (from pytest)
  Downloading https://files.pythonhosted.org/packages/71/c2/cb1855f0b2a0ae9ccc9b69f150a7aebd4a8d815bd951e74621c4154c52a8/importlib_metadata-4.8.1-py3-none-any.whl
Collecting packaging (from pytest)
  Downloading https://files.pythonhosted.org/packages/3c/77/e2362b676dc5008d81be423070dd9577fa03be5da2ba1105811900fda546/packaging-21.0-py3-none-any.whl (40kB)
    100% |████████████████████████████████| 40kB 9.5MB/s
Collecting tomli>=1.0.0 (from setuptools_scm)
  Downloading https://files.pythonhosted.org/packages/18/47/f7dab5b63b97efa7a715e389291d46246a5999c7b4705c2d147fc879e3b5/tomli-1.2.1-py3-none-any.whl
Collecting zipp; python_version < "3.8" (from pep517)
  Downloading https://files.pythonhosted.org/packages/92/d9/89f433969fb8dc5b9cbdd4b4deb587720ec1aeb59a020cf15002b9593eef/zipp-3.5.0-py3-none-any.whl
Collecting urllib3<1.27,>=1.21.1 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/5f/64/43575537846896abac0b15c3e5ac678d787a4021e906703f1766bfb8ea11/urllib3-1.26.6-py2.py3-none-any.whl (138kB)
    100% |████████████████████████████████| 143kB 7.8MB/s
Collecting idna<4,>=2.5; python_version >= "3" (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/d7/77/ff688d1504cdc4db2a938e2b7b9adee5dd52e34efbd2431051efc9984de9/idna-3.2-py3-none-any.whl (59kB)
    100% |████████████████████████████████| 61kB 9.9MB/s
Collecting certifi>=2017.4.17 (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/05/1b/0a0dece0e8aa492a6ec9e4ad2fe366b511558cdc73fd3abc82ba7348e875/certifi-2021.5.30-py2.py3-none-any.whl (145kB)
    100% |████████████████████████████████| 153kB 7.6MB/s
Collecting charset-normalizer~=2.0.0; python_version >= "3" (from requests>=1.0.0->coveralls)
  Downloading https://files.pythonhosted.org/packages/33/53/b7f6126a2b9fd878b025fe3c40266cfaad696f312165008ce045bffa3fe7/charset_normalizer-2.0.4-py3-none-any.whl
Collecting typing-extensions>=3.6.4; python_version < "3.8" (from importlib-metadata>=0.12; python_version < "3.8"->pytest)
  Downloading https://files.pythonhosted.org/packages/74/60/18783336cc7fcdd95dae91d73477830aa53f5d3181ae4fe20491d7fc3199/typing_extensions-3.10.0.2-py3-none-any.whl
Collecting pyparsing>=2.0.2 (from packaging->pytest)
  Downloading https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl (67kB)
    100% |████████████████████████████████| 71kB 9.9MB/s
Installing collected packages: urllib3, idna, certifi, charset-normalizer, requests, docopt, coveralls, six, asttokens, typing-extensions, zipp, importlib-metadata, pluggy, attrs, py, toml, iniconfig, pyparsing, packaging, pytest, setuptools, tomli, setuptools-scm, pep517
  Running setup.py install for docopt ... done
Successfully installed asttokens-2.0.5 attrs-21.2.0 certifi-2021.5.30 charset-normalizer-2.0.4 coveralls-3.2.0 docopt-0.6.2 idna-3.2 importlib-metadata-4.8.1 iniconfig-1.1.1 packaging-21.0 pep517-0.11.0 pluggy-1.0.0 py-1.10.0 pyparsing-2.4.7 pytest-6.2.5 requests-2.26.0 setuptools-58.0.2 setuptools-scm-6.3.1 six-1.16.0 toml-0.10.2 tomli-1.2.1 typing-extensions-3.10.0.2 urllib3-1.26.6 zipp-3.5.0
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Obtaining file:///root/executing
Installing collected packages: executing
  Running setup.py develop for executing
Successfully installed executing
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing executing.egg-info/PKG-INFO
writing dependency_links to executing.egg-info/dependency_links.txt
writing top-level names to executing.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE.txt'
writing manifest file 'executing.egg-info/SOURCES.txt'
running build_ext
test_files (tests.test_main.TestFiles) ... skipped 'These tests are very slow, enable them explicitly'
test_attr (tests.test_main.TestStuff) ... ok
test_closures_and_nested_comprehensions (tests.test_main.TestStuff) ... ok
test_compound_statements (tests.test_main.TestStuff) ... ok
test_comprehensions (tests.test_main.TestStuff) ... ok
test_decode_source (tests.test_main.TestStuff) ... ok
test_decorator (tests.test_main.TestStuff) ... ok
test_executing_methods (tests.test_main.TestStuff) ... ok
test_extended_arg (tests.test_main.TestStuff) ... ok
test_future_import (tests.test_main.TestStuff) ... 0.5
ok
test_generator (tests.test_main.TestStuff) ... ok
test_indirect_call (tests.test_main.TestStuff) ... ok
test_invalid_python (tests.test_main.TestStuff) ... ok
test_lambda (tests.test_main.TestStuff) ... ok
test_many_calls (tests.test_main.TestStuff) ... ok
test_multiline_strings (tests.test_main.TestStuff) ... ok
test_multiple_statements_on_one_line (tests.test_main.TestStuff) ... ok
test_names (tests.test_main.TestStuff) ... ok
test_only (tests.test_main.TestStuff) ... ok
test_qualname (tests.test_main.TestStuff) ... ok
test_retry_cache (tests.test_main.TestStuff) ... ok
test_semicolons (tests.test_main.TestStuff) ... ok
test_traceback (tests.test_main.TestStuff) ... ok

----------------------------------------------------------------------
Ran 23 tests in 17.444s

OK (skipped=1)
Build & Test Success for python 3.6 environment
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/executing
collected 1 item

tests/test_pytest.py .                                                                                                                                           [100%]

========================================================================== 1 passed in 0.57s ===========================================================================
coverage Test Success for python 3.6 environment
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
executing/executing.py     488    190    61%   57-79, 84-120, 125-126, 136, 158, 164, 166, 203-206, 217, 229-230, 237, 257, 267, 303-306, 330, 334-345, 397-398, 406-409, 413, 437-438, 462, 465, 468, 481, 490, 508-509, 515, 518-520, 557, 568, 570-586, 588-595, 600-608, 623, 628-657, 708-714, 739, 754, 779, 792, 825, 833-843, 851-869, 880-905, 916-929, 937-947, 972-975, 1002-1011
------------------------------------------------------
TOTAL                      488    190    61%
[root@2b692be8dbfb ~]#

Test 2 

sh executing_ubi_8.3.sh v0.6.0


Cloning into 'executing'...
remote: Enumerating objects: 905, done.
remote: Counting objects: 100% (236/236), done.
remote: Compressing objects: 100% (133/133), done.
remote: Total 905 (delta 116), reused 168 (delta 71), pack-reused 669
Receiving objects: 100% (905/905), 634.64 KiB | 2.66 MiB/s, done.
Resolving deltas: 100% (552/552), done.
Note: switching to 'v0.6.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 56d1e27 Switch from pep517 to new pypa build package
 found to checkout
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already satisfied: codecov in /usr/local/lib/python3.6/site-packages
Requirement already satisfied: coverage in /usr/local/lib/python3.6/site-packages (from codecov)
Requirement already satisfied: requests>=2.7.9 in /usr/local/lib/python3.6/site-packages (from codecov)
Requirement already satisfied: idna<4,>=2.5; python_version >= "3" in /usr/local/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Requirement already satisfied: charset-normalizer~=2.0.0; python_version >= "3" in /usr/local/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.6/site-packages (from requests>=2.7.9->codecov)
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already up-to-date: coveralls in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: asttokens in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: pytest in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: setuptools in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: setuptools_scm in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: pep517 in /usr/local/lib/python3.6/site-packages
Requirement already up-to-date: coverage<6.0,>=4.1 in /usr/local/lib/python3.6/site-packages (from coveralls)
Requirement already up-to-date: requests>=1.0.0 in /usr/local/lib/python3.6/site-packages (from coveralls)
Requirement already up-to-date: docopt>=0.6.1 in /usr/local/lib/python3.6/site-packages (from coveralls)
Requirement already up-to-date: six in /usr/local/lib/python3.6/site-packages (from asttokens)
Requirement already up-to-date: iniconfig in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: importlib-metadata>=0.12; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: packaging in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: attrs>=19.2.0 in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: pluggy<2.0,>=0.12 in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: toml in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: py>=1.8.2 in /usr/local/lib/python3.6/site-packages (from pytest)
Requirement already up-to-date: tomli>=1.0.0 in /usr/local/lib/python3.6/site-packages (from setuptools_scm)
Requirement already up-to-date: zipp; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from pep517)
Requirement already up-to-date: certifi>=2017.4.17 in /usr/local/lib/python3.6/site-packages (from requests>=1.0.0->coveralls)
Requirement already up-to-date: idna<4,>=2.5; python_version >= "3" in /usr/local/lib/python3.6/site-packages (from requests>=1.0.0->coveralls)
Requirement already up-to-date: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.6/site-packages (from requests>=1.0.0->coveralls)
Requirement already up-to-date: charset-normalizer~=2.0.0; python_version >= "3" in /usr/local/lib/python3.6/site-packages (from requests>=1.0.0->coveralls)
Requirement already up-to-date: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.6/site-packages (from importlib-metadata>=0.12; python_version < "3.8"->pytest)
Requirement already up-to-date: pyparsing>=2.0.2 in /usr/local/lib/python3.6/site-packages (from packaging->pytest)
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Obtaining file:///root/executing
Installing collected packages: executing
  Found existing installation: executing 0.6.0
    Can't uninstall 'executing'. No files were found to uninstall.
  Running setup.py develop for executing
Successfully installed executing
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing executing.egg-info/PKG-INFO
writing dependency_links to executing.egg-info/dependency_links.txt
writing top-level names to executing.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE.txt'
writing manifest file 'executing.egg-info/SOURCES.txt'
running build_ext
test_files (tests.test_main.TestFiles) ... skipped 'These tests are very slow, enable them explicitly'
test_attr (tests.test_main.TestStuff) ... ok
test_closures_and_nested_comprehensions (tests.test_main.TestStuff) ... ok
test_compound_statements (tests.test_main.TestStuff) ... ok
test_comprehensions (tests.test_main.TestStuff) ... ok
test_decode_source (tests.test_main.TestStuff) ... ok
test_decorator (tests.test_main.TestStuff) ... ok
test_executing_methods (tests.test_main.TestStuff) ... ok
test_extended_arg (tests.test_main.TestStuff) ... ok
test_future_import (tests.test_main.TestStuff) ... 0.5
ok
test_generator (tests.test_main.TestStuff) ... ok
test_indirect_call (tests.test_main.TestStuff) ... ok
test_invalid_python (tests.test_main.TestStuff) ... ok
test_lambda (tests.test_main.TestStuff) ... ok
test_many_calls (tests.test_main.TestStuff) ... ok
test_multiline_strings (tests.test_main.TestStuff) ... ok
test_multiple_statements_on_one_line (tests.test_main.TestStuff) ... ok
test_only (tests.test_main.TestStuff) ... ok
test_qualname (tests.test_main.TestStuff) ... ok
test_retry_cache (tests.test_main.TestStuff) ... ok
test_semicolons (tests.test_main.TestStuff) ... ok
test_traceback (tests.test_main.TestStuff) ... ok

----------------------------------------------------------------------
Ran 22 tests in 19.819s

OK (skipped=1)
Build & Test Success for python 3.6 environment
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/executing
collected 1 item

tests/test_pytest.py .                                                                                                                                           [100%]

========================================================================== 1 passed in 0.60s ===========================================================================
coverage Test Success for python 3.6 environment
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
executing/executing.py     375    103    73%   29-51, 55-87, 97, 119, 125, 127, 164-167, 178, 190-191, 213, 223, 259-262, 283, 285-296, 348-349, 357-360, 364, 388-389, 407, 410, 413, 426, 435, 453-454, 460, 463-465, 501, 510, 512, 514, 517-520, 603, 618, 662, 675, 708, 719-722, 749-758
------------------------------------------------------
TOTAL                      375    103    73%
[root@2b692be8dbfb ~]#
