### PR TITLE
Create rq_ubi_8.4.sh

### DIFF
--- a/r/rq/LICENSE
+++ b/r/rq/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/r/rq/rq_ubi_8.4.sh
+++ b/r/rq/rq_ubi_8.4.sh
@@ -1,0 +1,77 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : rq
+# Version       : v1.10
+# Source repo   : https://github.com/nvie/rq
+# Tested on     : UBI 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Gururaj R Katti <Gururaj.Katti@ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION=master
+else
+  export VERSION=$1
+fi
+
+if [ -d "rq" ] ; then
+  rm -rf rq
+fi
+
+# Dependency installation
+sudo dnf install -y python36 git wget gcc python36-devel procps make
+
+
+# Download the repos
+git clone https://github.com/nvie/rq
+
+cd rq
+git checkout $VERSION
+ret=$?
+if [ $ret -eq 0 ] ; then
+ echo "$Version found to checkout "
+else
+ echo "$Version not found "
+ exit
+fi
+
+# Clean up any previous redis-server
+kill -9 `ps -ef|grep redis-server | grep -v grep |awk '{print $2}'` 2>/dev/null
+
+# Download redis source and build
+wget http://download.redis.io/releases/redis-5.0.8.tar.gz
+tar xzf redis-5.0.8.tar.gz
+cd redis-5.0.8
+make
+cd ..
+sudo cp redis-5.0.8/src/redis-server /usr/bin
+ret=$?
+if [ $ret -eq 0 ] ; then
+ echo "Redis successfully built and installed"
+else
+ echo "Redis build failed"
+ exit
+fi
+# Start redis-server
+redis-server &
+
+# Build and Test rq
+
+sudo pip3 install redis==3.5.0
+sudo pip3 install -r requirements.txt -r dev-requirements.txt
+sudo pip3 install -e .
+ret=$?
+if [ $ret -ne 0 ] ; then
+ echo "dependency python pkg install failed "
+ exit
+else
+ pytest --cov=./ --cov-report=xml --durations=5
+fi


### PR DESCRIPTION
Since 1.8.0 has failures, testing only the latest version (1.10)
1. Valid argument
[testw@8d936b01b739 ~]$ ./rq_ubi_8.4.sh v1.10
.....
.....
Successfully installed rq
=========================== test session starts ============================
platform linux -- Python 3.6.8, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/testw/rq
plugins: cov-2.12.1
collected 333 items

tests/test_callbacks.py .......                                      [  2%]
tests/test_cli.py ..............................                     [ 11%]
tests/test_commands.py ...                                           [ 12%]
tests/test_connection.py .....                                       [ 13%]
tests/test_decorator.py .............                                [ 17%]
tests/test_fixtures.py ..                                            [ 18%]
tests/test_helpers.py .                                              [ 18%]
tests/test_job.py .................................................. [ 33%]
...........................                                          [ 41%]
tests/test_queue.py ................................................ [ 55%]
..                                                                   [ 56%]
tests/test_registry.py ...........................                   [ 64%]
tests/test_retry.py ......                                           [ 66%]
tests/test_scheduler.py ...............s...                          [ 72%]
tests/test_sentry.py ...                                             [ 72%]
tests/test_serializers.py .                                          [ 73%]
tests/test_utils.py ...............                                  [ 77%]
tests/test_worker.py ..............ss.................s.s........... [ 91%]
.......sssss...s..ss...                                              [ 98%]
tests/test_worker_registration.py ....                               [100%]

============================= warnings summary =============================
tests/test_cli.py::TestRQCli::test_info
tests/test_cli.py::TestRQCli::test_info
tests/test_cli.py::TestRQCli::test_info_only_queues
tests/test_cli.py::TestRQCli::test_info_only_queues
  /home/testw/rq/rq/cli/helpers.py:107: DeprecationWarning: 'click.get_terminal_size()' is deprecated and will be removed in Click 8.1. Use 'shutil.get_terminal_size()' instead.
    termwidth, _ = click.get_terminal_size()

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Coverage XML written to file coverage.xml

=========================== slowest 5 durations ============================
11.43s call     tests/test_cli.py::TestRQCli::test_cli_enqueue_schedule_in
6.63s call     tests/test_worker.py::TestWorker::test_custom_exc_handling
5.23s call     tests/test_scheduler.py::TestWorker::test_work_with_serializer
5.22s call     tests/test_scheduler.py::TestWorker::test_work
4.42s call     tests/test_worker.py::TestWorker::test_disable_default_exception_handler
========== 320 passed, 13 skipped, 4 warnings in 88.28s (0:01:28) ==========
[testw@8d936b01b739 ~]$
2. Invalid argument
[testw@8d936b01b739 ~]$ ./rq_ubi_8.4.sh 1.6.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 20:09:26 ago on Wed Sep 15 09:55:04 2021.
Package python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.ppc64le is already installed.
Package git-2.27.0-1.el8.ppc64le is already installed.
Package wget-1.19.5-10.el8.ppc64le is already installed.
Package gcc-8.4.1-1.el8.ppc64le is already installed.
Package python36-devel-3.6.8-2.module+el8.1.0+3334+5cb623d7.ppc64le is already installed.
Package procps-ng-3.3.15-6.el8.ppc64le is already installed.
Package make-1:4.2.1-10.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'rq'...
remote: Enumerating objects: 8630, done.
remote: Counting objects: 100% (430/430), done.
remote: Compressing objects: 100% (241/241), done.
remote: Total 8630 (delta 275), reused 293 (delta 186), pack-reused 8200
Receiving objects: 100% (8630/8630), 3.33 MiB | 11.07 MiB/s, done.
Resolving deltas: 100% (5618/5618), done.
error: pathspec '1.6.0' did not match any file(s) known to git
 not found
[testw@8d936b01b739 ~]$