### PR TITLE
Create yaml_ubi_8.4.sh

### DIFF
--- a/y/yaml/yaml_ubi_8.4.sh
+++ b/y/yaml/yaml_ubi_8.4.sh
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : yaml
+# Version       : v2.4.0,v2.3.0
+# Source repo   : https://github.com/go-yaml/yaml
+# Tested on     : UBI 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Gururaj R Katti <Gururaj.Katti@ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  export VERSION=v2
+else
+  export VERSION=$1
+fi
+
+if [ -d "yaml" ] ; then
+  rm -rf yaml
+fi
+
+# Dependency installation
+sudo yum module install -y go-toolset
+sudo dnf install -y git
+
+# Download the repos
+git clone https://github.com/go-yaml/yaml
+
+# Build and Test yaml
+cd yaml
+git checkout $VERSION
+ret=$?
+if [ $ret -eq 0 ] ; then
+ echo "$Version found to checkout "
+else
+ echo "$Version not found "
+ exit
+fi
+
+export GO111MODULE="auto"
+go get -v -t ./...
+ret=$?
+if [ $ret -ne 0 ] ; then
+ echo "go get failed "
+ exit
+else
+ go test -v ./...
+fi


### PR DESCRIPTION
1. Without argument
[test2@ac1729dd9887 ~]$ ./yaml_ubi_8.4.sh
......
.....
Already on 'v2'
Your branch is up to date with 'origin/v2'.
 found to checkout
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
gopkg.in/yaml.v2
=== RUN   Test
OK: 33 passed
--- PASS: Test (6.47s)
=== RUN   ExampleUnmarshal_embedded
--- PASS: ExampleUnmarshal_embedded (0.00s)
PASS
ok      gopkg.in/yaml.v2        6.485s
[test2@ac1729dd9887 ~]$

2. With invalid argument
[test2@ac1729dd9887 ~]$ ./yaml_ubi_8.4.sh v3.0.0-20200605160147-a5ece683394c
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:07:43 ago on Tue Sep 28 05:58:23 2021.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:07:45 ago on Tue Sep 28 05:58:23 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'yaml'...
remote: Enumerating objects: 1690, done.
remote: Total 1690 (delta 0), reused 0 (delta 0), pack-reused 1690
Receiving objects: 100% (1690/1690), 1.53 MiB | 5.00 MiB/s, done.
Resolving deltas: 100% (1098/1098), done.
error: pathspec 'v3.0.0-20200605160147-a5ece683394c' did not match any file(s) known to git
 not found
[test2@ac1729dd9887 ~]$

3. With valid argument
[test2@ac1729dd9887 ~]$ ./yaml_ubi_8.4.sh v2.3.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:08:36 ago on Tue Sep 28 05:58:23 2021.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:08:37 ago on Tue Sep 28 05:58:23 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'yaml'...
remote: Enumerating objects: 1690, done.
remote: Total 1690 (delta 0), reused 0 (delta 0), pack-reused 1690
Receiving objects: 100% (1690/1690), 1.53 MiB | 5.22 MiB/s, done.
Resolving deltas: 100% (1097/1097), done.
Note: switching to 'v2.3.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 0b1645d Set the default line length to infinity (-1) (#571)
 found to checkout
gopkg.in/yaml.v2
=== RUN   Test
OK: 32 passed
--- PASS: Test (6.47s)
=== RUN   ExampleUnmarshal_embedded
--- PASS: ExampleUnmarshal_embedded (0.00s)
PASS
ok      gopkg.in/yaml.v2        6.487s
[test2@ac1729dd9887 ~]$
