### PR TITLE
Add buildscripts for sub modules of kubernetes-client

### DIFF
--- a/k/kubernetes-client/kubernetes-model-apiextensions/kubernetes-model-apiextensions_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-apiextensions/kubernetes-model-apiextensions_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-apiextensions
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-apiextensions
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-apps/kubernetes-model-apps_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-apps/kubernetes-model-apps_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-apps
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-apps
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-batch/kubernetes-model-batch_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-batch/kubernetes-model-batch_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-batch
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-batch
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-common/kubernetes-model-common_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-common/kubernetes-model-common_ubi_8.4.sh
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-common
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-common
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $HOME/kubernetes-client
+cd $HOME/kubernetes-client
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+mvn clean install
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-core/kubernetes-model-core_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-core/kubernetes-model-core_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-core
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-core
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-extensions/kubernetes-model-extensions_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-extensions/kubernetes-model-extensions_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-extensions
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-extensions
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-networking/kubernetes-model-networking_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-networking/kubernetes-model-networking_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-networking
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-networking
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-policy/kubernetes-model-policy_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-policy/kubernetes-model-policy_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-policy
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-policy
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-rbac/kubernetes-model-rbac_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-rbac/kubernetes-model-rbac_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-rbac
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-rbac
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model-storageclass/kubernetes-model-storageclass_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model-storageclass/kubernetes-model-storageclass_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model-storageclass
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model-storageclass
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/kubernetes-model/kubernetes-model_ubi_8.4.sh
+++ b/k/kubernetes-client/kubernetes-model/kubernetes-model_ubi_8.4.sh
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : kubernetes-model
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/kubernetes-model
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $HOME/kubernetes-client
+cd $HOME/kubernetes-client
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+mvn clean install
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/openshift-client/openshift-client_ubi_8.4.sh
+++ b/k/kubernetes-client/openshift-client/openshift-client_ubi_8.4.sh
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : openshift-client
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=openshift-client
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $HOME/kubernetes-client
+cd $HOME/kubernetes-client
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+mvn clean install
+
+# generated jars 
+find -name *.jar

--- a/k/kubernetes-client/openshift-model-monitoring/openshift-model-monitoring_ubi_8.4.sh
+++ b/k/kubernetes-client/openshift-model-monitoring/openshift-model-monitoring_ubi_8.4.sh
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+#
+# Package       : openshift-model-monitoring
+# Version       : v5.0.2
+# Source repo   : https://github.com/fabric8io/kubernetes-client.git
+# Tested on     : ubi 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=kubernetes-model-generator/openshift-model-monitoring
+PACKAGE_VERSION=${1:-v5.0.2}
+PACKAGE_URL=https://github.com/fabric8io/kubernetes-client.git
+
+yum -y update
+yum install -y make git curl wget java-1.8.0-openjdk-devel
+
+# install maven
+wget https://downloads.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /tmp 
+tar -xzf /tmp/apache-maven-3.8.3-bin.tar.gz -C /opt/
+export M2_HOME=/opt/apache-maven-3.8.3
+export PATH=$M2_HOME/bin/:$PATH
+mvn --version
+
+# install go
+wget https://golang.org/dl/go1.16.linux-ppc64le.tar.gz -P /tmp
+tar -xf /tmp/go1.16.linux-ppc64le.tar.gz -C /opt/
+export GOROOT=/opt/go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+# clone source & checkout version
+git clone $PACKAGE_URL $GOPATH/src/github.com/fabric8io/kubernetes-client
+cd $GOPATH/src/github.com/fabric8io/kubernetes-client/
+git checkout $PACKAGE_VERSION
+
+# build package
+cd $PACKAGE_NAME
+make all
+
+# generated jars 
+find -name *.jar


### PR DESCRIPTION
This is follow up PR of #1119 to add buildscripts for remaining sub modules of `kubernetes-client` package.

Sub Modules:
```
kubernetes-model
kubernetes-model-apiextensions
kubernetes-model-apps
kubernetes-model-batch
kubernetes-model-common
kubernetes-model-core
kubernetes-model-extensions
kubernetes-model-networking
kubernetes-model-policy
kubernetes-model-rbac
kubernetes-model-storageclass
openshift-model-monitoring
openshift-client
```
