### PR TITLE
Create automaxprocs_ubi_8.4.sh

### DIFF
--- a/a/automaxprocs/LICENSE
+++ b/a/automaxprocs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/a/automaxprocs/automaxprocs_ubi_8.4.sh
+++ b/a/automaxprocs/automaxprocs_ubi_8.4.sh
@@ -1,0 +1,41 @@
+# ----------------------------------------------------------------------------
+#
+# Package       : automaxprocs
+# Version       : v1.4.0
+# Source repo   : https://github.com/uber-go/automaxprocs
+# Tested on     : UBI 8.4
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Gururaj R Katti <Gururaj.Katti@ibm.com>
+#
+# Disclaimer: This script has been tested in non-root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#!/bin/bash
+
+set -eu
+
+VERSION="${1:-v1.4.0}"
+
+if [ -d "automaxprocs" ] ; then
+  rm -rf automaxprocs
+fi
+
+# Dependency installation
+sudo yum module install -y go-toolset
+sudo dnf install -y git make
+
+# Download the repos
+git clone https://github.com/uber-go/automaxprocs
+
+# Build and Test automaxprocs
+cd automaxprocs
+git checkout $VERSION
+export GO111MODULE="auto"
+go vet ./...
+make lint
+make test
+make cover


### PR DESCRIPTION
1. With invalid argument
[testw@ff7d9d94784c ~]$ ./automaxprocs_ubi_8.4.sh 1.0.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 20:59:57 ago on Wed Oct 27 10:29:08 2021.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 21:00:01 ago on Wed Oct 27 10:29:08 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Package make-1:4.2.1-10.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'automaxprocs'...
remote: Enumerating objects: 345, done.
remote: Counting objects: 100% (54/54), done.
remote: Compressing objects: 100% (41/41), done.
remote: Total 345 (delta 16), reused 24 (delta 8), pack-reused 291
Receiving objects: 100% (345/345), 76.42 KiB | 724.00 KiB/s, done.
Resolving deltas: 100% (161/161), done.
error: pathspec '1.0.0' did not match any file(s) known to git
[testw@ff7d9d94784c ~]$

2. With valid argument

[testw@ff7d9d94784c ~]$ ./automaxprocs_ubi_8.4.sh v1.3.0
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:05:58 ago on Wed Oct 27 10:29:08 2021.
Dependencies resolved.
Nothing to do.
Complete!
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

Last metadata expiration check: 0:05:59 ago on Wed Oct 27 10:29:08 2021.
Package git-2.27.0-1.el8.ppc64le is already installed.
Package make-1:4.2.1-10.el8.ppc64le is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Cloning into 'automaxprocs'...
remote: Enumerating objects: 345, done.
remote: Counting objects: 100% (54/54), done.
remote: Compressing objects: 100% (41/41), done.
remote: Total 345 (delta 16), reused 24 (delta 8), pack-reused 291
Receiving objects: 100% (345/345), 76.42 KiB | 674.00 KiB/s, done.
Resolving deltas: 100% (161/161), done.
Note: switching to 'v1.3.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at e393bb0 Preparing release v1.3.0 (#25)
go: downloading github.com/stretchr/testify v1.4.0
go: downloading github.com/davecgh/go-spew v1.1.0
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/pmezard/go-difflib v1.0.0
go install golang.org/x/lint/golint
go: downloading golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
go: downloading golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f
go install honnef.co/go/tools/cmd/staticcheck
go: downloading honnef.co/go/tools v0.0.1-2019.2.3
go: downloading github.com/BurntSushi/toml v0.3.1
Checking gofmt
Checking go vet
Checking golint
Checking staticcheck
Checking for license headers...
go test -race ./...
ok      go.uber.org/automaxprocs        0.003s
ok      go.uber.org/automaxprocs/internal/cgroups       0.010s
?       go.uber.org/automaxprocs/internal/runtime       [no test files]
ok      go.uber.org/automaxprocs/maxprocs       0.003s
go test -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
ok      go.uber.org/automaxprocs        0.011s  coverage: 65.4% of statements in ./... [no tests to run]
ok      go.uber.org/automaxprocs/internal/cgroups       0.010s  coverage: 83.0% of statements in ./...
?       go.uber.org/automaxprocs/internal/runtime       [no test files]
ok      go.uber.org/automaxprocs/maxprocs       0.007s  coverage: 75.8% of statements in ./...
go tool cover -html=cover.out -o cover.html
[testw@ff7d9d94784c ~]$

3. Without argument

[testw@6eb86fda4a5a ~]$ ./automaxprocs_ubi_8.4.sh
.....
.....
....
HEAD is now at 1c8b231 Release v1.4.0
go: downloading github.com/stretchr/testify v1.4.0
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/davecgh/go-spew v1.1.0
cd tools && go install golang.org/x/lint/golint
go: downloading golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
go: downloading golang.org/x/tools v0.1.0
cd tools && go install honnef.co/go/tools/cmd/staticcheck
go: downloading honnef.co/go/tools v0.1.1
go: downloading github.com/BurntSushi/toml v0.3.1
go: downloading golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.4.1
Checking gofmt
Checking go vet
Checking golint
Checking staticcheck
Checking for license headers...
go test -race ./...
ok      go.uber.org/automaxprocs        0.002s
ok      go.uber.org/automaxprocs/internal/cgroups       0.004s
?       go.uber.org/automaxprocs/internal/runtime       [no test files]
ok      go.uber.org/automaxprocs/maxprocs       0.002s
go test -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
ok      go.uber.org/automaxprocs        0.011s  coverage: 65.4% of statements in ./... [no tests to run]
ok      go.uber.org/automaxprocs/internal/cgroups       0.037s  coverage: 83.0% of statements in ./...
?       go.uber.org/automaxprocs/internal/runtime       [no test files]
ok      go.uber.org/automaxprocs/maxprocs       0.006s  coverage: 75.8% of statements in ./...
go tool cover -html=cover.out -o cover.html
[testw@6eb86fda4a5a ~]$
