### PR TITLE
Fixing travis build timeout bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ script:
     - sudo apt update -y
     - pip3 install requests
     - pip3 install docker
-    - python3 script/validate_builds.py $TRAVIS_PULL_REQUEST
+    - python3 script/validate_builds.py $TRAVIS_PULL_REQUEST &
+    - SCRIPT_PID=$!;while ps -p $SCRIPT_PID > /dev/null;do echo "$SCRIPT_PID is running"; sleep 300; done; wait $SCRIPT_PID; my_pid_status=$?; travis_terminate $my_pid_status


### PR DESCRIPTION
For packages requiring build time longer than 10 minutes, travis build times out if no output is received. Added logic to keep the build active.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
