### PR TITLE
Added build script line endings check to travis validation script  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - docker pull registry.access.redhat.com/ubi8/ubi:8.5
 
 script:
-    - sudo apt update -y
+    - sudo apt update -y && sudo apt-get install file -y
     - pip3 install requests
     - pip3 install docker
     - python3 script/validate_builds.py $TRAVIS_PULL_REQUEST &

--- a/script/validate_builds.py
+++ b/script/validate_builds.py
@@ -30,6 +30,11 @@ def trigger_basic_validation_checks(file_name):
 
     # Check if components of Doc string are available.
     script_path = "{}/{}".format(HOME, file_name)
+    
+    #Check build script line endings 
+    eof=os.popen('file '+script_path).read()
+    if 'crlf' in eof.lower():
+        raise EOFError("Build script {} contains windows line endings(CRLF), Please update build script with Linux based line endings.".format(file_name))
 
     if os.path.exists(script_path):
         all_lines = []


### PR DESCRIPTION
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?

Travis build script validation will be triggered only if build script contains Linux based line endings.