### PR TITLE
Update versions for crunchy-containers, genproto, go-oidc & go-spew b…

### DIFF
--- a/c/crunchy-containers/crunchy-containers_ubi_8.5.sh
+++ b/c/crunchy-containers/crunchy-containers_ubi_8.5.sh
@@ -3,7 +3,7 @@
 # ----------------------------------------------------------------------------
 #
 # Package               : crunchy-containers
-# Version               : v4.7.2
+# Version               : v4.7.2, v4.5.1
 # Source repo           : https://github.com/CrunchyData/crunchy-containers
 # Tested on             : RHEL 8.5,UBI 8.5
 # Language              : GO

--- a/g/genproto/genproto_ubi_8.5.sh
+++ b/g/genproto/genproto_ubi_8.5.sh
@@ -1,11 +1,14 @@
+#!/bin/bash -e
 # -----------------------------------------------------------------------------
 #
-# Package	: google.golang.org/genproto
-# Version	: v0.0.0
+# Package	    : google.golang.org/genproto
+# Version	    : v0.0.0, 0.0.0-20210204154452-deb828366460
 # Source repo	: https://pkg.go.dev/google.golang.org/genproto
-# Tested on	: UBI 8.5
+# Tested on	    : UBI 8.5
 # Script License: Apache License, Version 2 or later
 # Maintainer	: Atharv Phadnis <Atharv.Phadnis@ibm.com>
+# Language      : GO
+# Travis-Check  : True
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.

--- a/g/genproto/genproto_ubi_8.5.sh
+++ b/g/genproto/genproto_ubi_8.5.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 # -----------------------------------------------------------------------------
 #
-# Package	    : google.golang.org/genproto
-# Version	    : v0.0.0, 0.0.0-20210204154452-deb828366460
+# Package	: google.golang.org/genproto
+# Version	: v0.0.0, 0.0.0-20210204154452-deb828366460
 # Source repo	: https://pkg.go.dev/google.golang.org/genproto
-# Tested on	    : UBI 8.5
+# Tested on	: UBI 8.5
 # Script License: Apache License, Version 2 or later
-# Maintainer	: Atharv Phadnis <Atharv.Phadnis@ibm.com>
+# Maintainer	: Atharv Phadnis <Atharv.Phadnis@ibm.com>/ Balavva Mirji <Balavva.Mirji@ibm.com>
 # Language      : GO
 # Travis-Check  : True
 #

--- a/g/go-oidc/go-oidc_ubi_8.5.sh
+++ b/g/go-oidc/go-oidc_ubi_8.5.sh
@@ -2,7 +2,7 @@
 # -----------------------------------------------------------------------------
 #
 # Package	: go-oidc
-# Version	: v2.1.0
+# Version	: v2.1.0, v0.0.0-20180117170138-065b426bd416
 # Source repo	: https://github.com/coreos/go-oidc.git
 # Tested on	: UBI: 8.5
 # Language      : GO

--- a/g/go-oidc/go-oidc_ubi_8.5.sh
+++ b/g/go-oidc/go-oidc_ubi_8.5.sh
@@ -8,7 +8,7 @@
 # Language      : GO
 # Travis-Check  : True
 # Script License: Apache License, Version 2 or later
-# Maintainer	: Reynold Vaz <Reynold.Vaz@ibm.com>
+# Maintainer	: Reynold Vaz <Reynold.Vaz@ibm.com>/ Balavva Mirji <Balavva.Mirji@ibm.com>
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.
@@ -24,6 +24,8 @@ PACKAGE_NAME=go-oidc
 PACKAGE_VERSION=${1:-v2.1.0}
 PACKAGE_URL=https://github.com/coreos/go-oidc.git
 
+PACKAGE_COMMIT_HASH=`echo $PACKAGE_VERSION | cut -d'-' -f3`
+
 yum install go git -y
 
 export GOPATH=/home/tester/go
@@ -32,22 +34,14 @@ OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
 mkdir -p $GOPATH/src/github.com/coreos && cd $GOPATH/src/github.com/coreos
 git clone $PACKAGE_URL
 cd $PACKAGE_NAME
-git checkout $PACKAGE_VERSION
-
-go get -u golang.org/x/lint/golint
-cp /home/tester/go/bin/golint /usr/bin
-go get -v -t github.com/coreos/go-oidc/...
-go get golang.org/x/tools/cmd/cover
+git checkout $PACKAGE_COMMIT_HASH
 
 go mod init
-go mod tidy
+#To upgrade to the versions selected by go 1.16
+go mod tidy -go=1.16 && go mod tidy -go=1.17
 
-if ! ./test ; then
-	echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
-	echo "$PACKAGE_NAME  |  $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Install_success_but_test_Fails" 
-	exit 1
-else
-	echo "------------------$PACKAGE_NAME:install_&_test_both_success-------------------------"
-	echo "$PACKAGE_NAME  |  $PACKAGE_VERSION | $OS_NAME | GitHub  | Pass |  Both_Install_and_Test_Success"
-	exit 0
-fi
+go install ./...
+go test -v ./...
+
+exit 0
+

--- a/g/go-oidc/go-oidc_ubi_8.5.sh
+++ b/g/go-oidc/go-oidc_ubi_8.5.sh
@@ -69,4 +69,3 @@ else
         echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub  | Pass |  Build_and_Test_Success"
         exit 0
 fi
-

--- a/g/go-oidc/go-oidc_ubi_8.5.sh
+++ b/g/go-oidc/go-oidc_ubi_8.5.sh
@@ -36,12 +36,37 @@ git clone $PACKAGE_URL
 cd $PACKAGE_NAME
 git checkout $PACKAGE_COMMIT_HASH
 
-go mod init
+if ! go mod init; then
+        echo "------------------$PACKAGE_NAME:initialize_fails-------------------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub | Fail |  Initialize_Fails"
+        exit 1
+fi
+
 #To upgrade to the versions selected by go 1.16
-go mod tidy -go=1.16 && go mod tidy -go=1.17
+if ! go mod tidy -go=1.16 && go mod tidy -go=1.17; then
+        echo "------------------$PACKAGE_NAME:dependency_fails-------------------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub | Fail |  Dependency_Fails"
+        exit 1
+fi
 
-go install ./...
-go test -v ./...
+if ! go install ./...; then
+        echo "------------------$PACKAGE_NAME:install_fails-------------------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+        exit 1
+fi
 
-exit 0
+if ! go test -v ./...; then
+        echo "------------------$PACKAGE_NAME:test_fails---------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub | Fail |  Test_Fails"
+        exit 1
+else
+        echo "------------------$PACKAGE_NAME:install_and_test_success-------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | GitHub  | Pass |  Build_and_Test_Success"
+        exit 0
+fi
 

--- a/g/go-spew/go-spew_ubi_8.5.sh
+++ b/g/go-spew/go-spew_ubi_8.5.sh
@@ -1,9 +1,12 @@
+#!/bin/bash -e
 # -----------------------------------------------------------------------------
 #
 # Package	: github.com/davecgh/go-spew
-# Version	: v1.1.1
+# Version	: v1.1.1, v0.0.0-20151105211317-5215b55f46b2
 # Source repo	: https://github.com/davecgh/go-spew
 # Tested on	: UBI 8.5
+# Language      : GO
+# Travis-Check  : True
 # Script License: Apache License, Version 2 or later
 # Maintainer	: Atharv Phadnis <Atharv.Phadnis@ibm.com>
 #


### PR DESCRIPTION
…uild scripts

## Checklist
<!--- Go to Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

Referring to PR https://github.com/ppc64le/build-scripts/pull/1405 
For crunchy-containers, genproto, go-oidc & go-spew build scripts are already present, so updated the requested versions in the existing scripts only.