### PR TITLE
Updated the requests and docker installation commands in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 script:
     - sudo apt update -y && sudo apt-get install file -y
-    - pip3 install requests
-    - pip3 install docker
+    - pip3 install --upgrade requests
+    - pip3 install --upgrade docker
     - python3 script/validate_builds.py $TRAVIS_PULL_REQUEST &
     - SCRIPT_PID=$!;while ps -p $SCRIPT_PID > /dev/null;do echo "$SCRIPT_PID is running"; sleep 300; done; wait $SCRIPT_PID; my_pid_status=$?; travis_terminate $my_pid_status


### PR DESCRIPTION
we are seeing issues with Travis pr builds getting failed with no logs output after the completion of basic checks passed step. After a thorough investigation we found compatibility issues with respect to python requests library as well as docker SDK for python.
Error details: **Error while fetching server API version: request() got an unexpected keyword argument 'chunked'**
we recorded this above error while trying to set a docker client in the script.
**try:
   client = docker.DockerClient(base_url='unix://var/run/docker.sock')
except docker.errors.DockerException as e:
   print(f"{e}")**
  
Took a reference from the below mentioned Github issue.
Reference: **https://github.com/karfly/chatgpt_telegram_bot/issues/324**
