### PR TITLE
Limiting the Travis builds for pull requests and api events only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+# Travis builds are triggered for pull requests and api events only and all push events will be blocked.
 if: type IN (api, pull_request)
 
+# will import the desired travis config file based on the request type.
 import:
 - source: travis-currency-ymls/pr-build.yml
   if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Travis builds are triggered for pull requests and api events only and all push events will be blocked.
+# Travis builds are triggered for pull requests and api events only.
 if: type IN (api, pull_request)
 
 # will import the desired travis config file based on the request type.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: type IN (api, pull_request)
+
 import:
 - source: travis-currency-ymls/pr-build.yml
   if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ import:
 - source: travis-currency-ymls/pr-build.yml
   if: type = pull_request
 - source: travis-currency-ymls/currency-build.yml
-  if: type != pull_request
+  if: type = api


### PR DESCRIPTION
-> Added a condition to check the event type.
note: we can disable the push builds from the console itself under the repo settings
