### PR TITLE
code changes required for migrating to ubi9.3

### DIFF
--- a/script/dockerfile_non_root
+++ b/script/dockerfile_non_root
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+#FROM registry.access.redhat.com/ubi8/ubi:8.7
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 RUN yum install -y sudo
 RUN echo 'test_user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/test_user
 RUN useradd -d /home/tester -m -s /bin/bash test_user

--- a/script/read_buildinfo.sh
+++ b/script/read_buildinfo.sh
@@ -81,6 +81,22 @@ if [ -f $config_file ]; then
   fi
 fi
 
+build_script_with_quotes=$build_script
+stripped_build_script=$(echo "$build_script_with_quotes" | sed 's/"//g')
+echo $stripped_build_script
+if [ -f $stripped_build_script ]; then
+  echo "build script found"
+  while IFS= read -r line; do
+      # Check if the line starts with '# Tested on'
+      if [[ "$line" == "# Tested on"* ]]; then
+          # Extract the value after the first colon
+          tested_on=$(echo "$line" | cut -d ':' -f 2- | tr -d '[:space:]')
+          break
+      fi
+  done < "$stripped_build_script"  # Use input redirection from the file
+  echo "Tested on value: $tested_on"
+fi
+
 
 echo "export VERSION=$VERSION" > $CUR_DIR/variable.sh
 echo "export BUILD_SCRIPT=$build_script" >> $CUR_DIR/variable.sh
@@ -91,6 +107,7 @@ echo "export VALIDATE_BUILD_SCRIPT=$validate_build_script" >> $CUR_DIR/variable.
 echo "export VARIANT=$variant" >> $CUR_DIR/variable.sh
 echo "export BASENAME=$basename" >> $CUR_DIR/variable.sh
 echo "export NON_ROOT_BUILD=$nonRootBuild" >> $CUR_DIR/variable.sh
+echo "export TESTED_ON=$tested_on" >> $CUR_DIR/variable.sh
 
 chmod +x $CUR_DIR/variable.sh
 cat $CUR_DIR/variable.sh

--- a/travis-currency-ymls/pr-build.yml
+++ b/travis-currency-ymls/pr-build.yml
@@ -8,7 +8,7 @@ services:
     - docker
 
 before_install:
-    - docker pull registry.access.redhat.com/ubi8/ubi:8.7
+    - docker pull registry.access.redhat.com/ubi9/ubi:9.3
 
 script:
     - sudo apt update -y && sudo apt-get install file -y


### PR DESCRIPTION
-> updated the base image to ubi9.3 for pr builds. 
-> Added necessary code required for building packages for different base images, mainly ubi 8 and ubi 9.
-> updated the code related to non root user build.
-> updated the custom docker image file which is used as part of non root user build.