### PR TITLE
code changes required for migrating to ubi9.3

### DIFF
--- a/script/build_package.sh
+++ b/script/build_package.sh
@@ -23,7 +23,7 @@ docker_build_non_root() {
   docker_image="docker_non_root_image"
 }
 
-#for testing
+#Below conditions are used to select the base image based on the 2 flags, tested_on and non_root_build. 
 if [[ "$TESTED_ON" == UBI:9* ]];
 then
     docker pull registry.access.redhat.com/ubi9/ubi:9.3
@@ -32,16 +32,13 @@ then
     then
         docker_build_non_root "registry.access.redhat.com/ubi9/ubi:9.3"
     fi
-elif [[ "$TESTED_ON" == UBI:8* ]];
-then
+else
     docker pull registry.access.redhat.com/ubi8/ubi:8.7
     docker_image="registry.access.redhat.com/ubi8/ubi:8.7"
     if [[ "$NON_ROOT_BUILD" == "true" ]];
     then
         docker_build_non_root "registry.access.redhat.com/ubi8/ubi:8.7"
     fi    
-else
-    echo "Tested_on value of $TESTED_ON is not satisfied"
 fi
 
 python3 script/validate_builds_currency.py "$PKG_DIR_PATH$BUILD_SCRIPT" "$VERSION" "$docker_image" > build_log &

--- a/script/build_package.sh
+++ b/script/build_package.sh
@@ -8,22 +8,16 @@ echo "Running build script execution in background for "$PKG_DIR_PATH$BUILD_SCRI
 echo "*************************************************************************************"
 
 docker_image=""
-:' 
-if [ "$NON_ROOT_BUILD" == "true" ];
-then
-    echo "building docker image for non root user build"
-    docker build -t docker_non_root_image -f script/dockerfile_non_root .
-    docker_image="docker_non_root_image"
-fi
-':
 
+# the below function is used for building a custom docker image, it will be called only when non root user build is set to true.
+# function accepts one argument, which is the base image value.
 docker_build_non_root() {
   echo "building docker image for non root user build"
   docker build --build-arg BASE_IMAGE="$1" -t docker_non_root_image -f script/dockerfile_non_root .
   docker_image="docker_non_root_image"
 }
 
-#Below conditions are used to select the base image based on the 2 flags, tested_on and non_root_build. 
+#Below conditions are used to select the base image based on the 2 flags, tested_on and non_root_build. A docker_build_non_root function is called when non root build is true.
 if [[ "$TESTED_ON" == UBI:9* ]];
 then
     docker pull registry.access.redhat.com/ubi9/ubi:9.3

--- a/script/dockerfile_non_root
+++ b/script/dockerfile_non_root
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+#FROM registry.access.redhat.com/ubi8/ubi:8.7
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 RUN yum install -y sudo
 RUN echo 'test_user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/test_user
 RUN useradd -d /home/tester -m -s /bin/bash test_user

--- a/script/read_buildinfo.sh
+++ b/script/read_buildinfo.sh
@@ -81,6 +81,22 @@ if [ -f $config_file ]; then
   fi
 fi
 
+build_script_with_quotes=$build_script
+stripped_build_script=$(echo "$build_script_with_quotes" | sed 's/"//g')
+echo $stripped_build_script
+if [ -f $stripped_build_script ]; then
+  echo "build script found"
+  while IFS= read -r line; do
+      # Check if the line starts with '# Tested on'
+      if [[ "$line" == "# Tested on"* ]]; then
+          # Extract the value after the first colon
+          tested_on=$(echo "$line" | cut -d ':' -f 2- | tr -d '[:space:]')
+          break
+      fi
+  done < "$stripped_build_script"  # Use input redirection from the file
+  echo "Tested on value: $tested_on"
+fi
+
 
 echo "export VERSION=$VERSION" > $CUR_DIR/variable.sh
 echo "export BUILD_SCRIPT=$build_script" >> $CUR_DIR/variable.sh
@@ -91,6 +107,7 @@ echo "export VALIDATE_BUILD_SCRIPT=$validate_build_script" >> $CUR_DIR/variable.
 echo "export VARIANT=$variant" >> $CUR_DIR/variable.sh
 echo "export BASENAME=$basename" >> $CUR_DIR/variable.sh
 echo "export NON_ROOT_BUILD=$nonRootBuild" >> $CUR_DIR/variable.sh
+echo "export TESTED_ON=$tested_on" >> $CUR_DIR/variable.sh
 
 chmod +x $CUR_DIR/variable.sh
 cat $CUR_DIR/variable.sh

--- a/script/read_buildinfo.sh
+++ b/script/read_buildinfo.sh
@@ -81,6 +81,7 @@ if [ -f $config_file ]; then
   fi
 fi
 
+# Below code is used to get the tested on parameter value from the build script
 build_script_with_quotes=$build_script
 stripped_build_script=$(echo "$build_script_with_quotes" | sed 's/"//g')
 echo $stripped_build_script

--- a/travis-currency-ymls/pr-build.yml
+++ b/travis-currency-ymls/pr-build.yml
@@ -8,7 +8,7 @@ services:
     - docker
 
 before_install:
-    - docker pull registry.access.redhat.com/ubi8/ubi:8.7
+    - docker pull registry.access.redhat.com/ubi9/ubi:9.3
 
 script:
     - sudo apt update -y && sudo apt-get install file -y


### PR DESCRIPTION
-> updated the base image to ubi9.3 for pr builds.
-> Added necessary code required for building packages for different base images, mainly ubi 8 and ubi 9.
-> updated the code related to non root user build.
-> updated the custom docker image file which is used as part of non root user build.