### PR TITLE
Added build scripts and build_info.json files for scikit-learn.

### DIFF
--- a/s/scikit-learn/build_info.json
+++ b/s/scikit-learn/build_info.json
@@ -1,0 +1,12 @@
+{
+   "maintainer": "Salil4IBM",
+   "package_name": "scikit-learn",
+   "github_url": "https://github.com/scikit-learn/scikit-learn.git",
+   "version": "1.5.2",
+   "default_branch": "main",
+   "build_script": "scikit-learn_ubi_9.3.sh",
+   "package_dir": "s/scikit-learn",
+   "docker_build": false,
+   "validate_build_script": true,
+   "use_non_root_user": false
+}

--- a/s/scikit-learn/scikit-learn_ubi_8.10.sh
+++ b/s/scikit-learn/scikit-learn_ubi_8.10.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : scikit-learn
+# Version       : 1.5.0
+# Source repo   : https://github.com/scikit-learn/scikit-learn.git
+# Tested on     : UBI 8.10
+# Language      : Python, Cython, C++
+# Travis-Check  : False
+# Script License: Apache License 2.0
+# Maintainer    : Salil Verlekar <Salil.Verlekar2@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+PACKAGE_NAME=scikit-learn
+PACKAGE_VERSION=${1:-1.5.0}
+PACKAGE_URL=https://github.com/scikit-learn/scikit-learn.git
+
+yum install -y python3.11 python3.11-pip python3.11-devel gcc gcc-c++ gcc-gfortran gcc-toolset-10 git
+yum install -y openblas-devel --enablerepo=codeready-builder-for-rhel-8-ppc64le-rpms
+
+source /opt/rh/gcc-toolset-10/enable
+
+OS_NAME=$(cat /etc/os-release | grep ^PRETTY_NAME | cut -d= -f2)
+
+# clone source repository
+git clone $PACKAGE_URL
+cd $PACKAGE_NAME
+git checkout $PACKAGE_VERSION
+git submodule update --init
+
+# install scikit-learn dependencies and build dependencies
+python3.11 -m pip install wheel numpy scipy cython meson-python ninja 'pytest==8.2.2' 'patchelf>=0.11.0' build
+
+export SKLEARN_SKIP_OPENMP_TEST=1
+
+ln -s /usr/bin/python3.11 python
+mv python /usr/bin
+
+# build wheel in /scikit-learn/dist
+if ! python3.11 -m build --wheel --no-isolation; then
+        echo "------------------$PACKAGE_NAME:build_fails---------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Build_Fails"
+        exit 1
+else
+        echo "------------------$PACKAGE_NAME:build_success-------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | $OS_NAME | GitHub  | Pass |  Build_Success"
+fi
+
+# install wheel, run show and check that the installed scikit-learn has a version number
+python3.11 -m pip install dist/scikit_learn-1.5.0-cp311-cp311-linux_ppc64le.whl
+python3.11 -m pip show scikit-learn
+cd sklearn
+python3.11 -c "import sklearn; sklearn.show_versions()"
+
+if [ $? == 0 ]; then
+     echo "------------------$PACKAGE_NAME::Install_Success---------------------"
+     echo "$PACKAGE_VERSION $PACKAGE_NAME"
+     echo "$PACKAGE_NAME  | $PACKAGE_URL | $PACKAGE_VERSION  | Pass |  Install_Success"
+else
+     echo "------------------$PACKAGE_NAME::Install_Fail-------------------------"
+     echo "$PACKAGE_VERSION $PACKAGE_NAME"
+     echo "$PACKAGE_NAME  | $PACKAGE_URL | $PACKAGE_VERSION  | Fail |  Install_Fail"
+     exit 2
+fi
+
+# test using pytest - set below flag as suggested in GitHub forums to resolve ImportPathMismatchError
+export PY_IGNORE_IMPORTMISMATCH=1
+if ! pytest tests/test_random_projection.py ; then
+        echo "------------------$PACKAGE_NAME:test_fails---------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME "
+        echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | Github | Fail |  Test_Fails"
+        exit 2
+else
+        echo "------------------$PACKAGE_NAME:test_success-------------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME "
+        echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | Github | Pass |  Test_Success"
+	exit 0
+fi

--- a/s/scikit-learn/scikit-learn_ubi_9.3.sh
+++ b/s/scikit-learn/scikit-learn_ubi_9.3.sh
@@ -70,7 +70,7 @@ fi
 
 # test using pytest - set below flag as suggested in GitHub forums to resolve ImportPathMismatchError
 export PY_IGNORE_IMPORTMISMATCH=1
-if ! pytest sklearn/tests/test_common.py ; then
+if ! pytest sklearn/tests/test_random_projection.py ; then
         echo "------------------$PACKAGE_NAME:test_fails---------------------"
         echo "$PACKAGE_URL $PACKAGE_NAME "
         echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | Github | Fail |  Test_Fails"

--- a/s/scikit-learn/scikit-learn_ubi_9.3.sh
+++ b/s/scikit-learn/scikit-learn_ubi_9.3.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : scikit-learn
+# Version       : 1.5.2
+# Source repo   : https://github.com/scikit-learn/scikit-learn.git
+# Tested on     : UBI 9.3
+# Language      : Python, Cython, C++
+# Travis-Check  : True
+# Script License: Apache License 2.0
+# Maintainer    : Salil Verlekar <Salil.Verlekar2@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+PACKAGE_NAME=scikit-learn
+PACKAGE_VERSION=${1:-1.5.2}
+PACKAGE_URL=https://github.com/scikit-learn/scikit-learn.git
+
+yum install -y python3.11 python3.11-pip python3.11-devel gcc gcc-c++ gcc-gfortran openblas-devel gcc-toolset-12 git
+
+source /opt/rh/gcc-toolset-12/enable
+
+OS_NAME=$(cat /etc/os-release | grep ^PRETTY_NAME | cut -d= -f2)
+
+# clone source repository
+git clone $PACKAGE_URL
+cd $PACKAGE_NAME
+git checkout $PACKAGE_VERSION
+git submodule update --init
+
+# install scikit-learn dependencies and build dependencies
+python3.11 -m pip install wheel numpy scipy cython meson-python ninja 'pytest==8.2.2'
+
+export SKLEARN_SKIP_OPENMP_TEST=1
+
+ln -s /usr/bin/python3.11 python
+mv python /usr/bin
+
+# build the project with pip and install
+if ! python3.11 -m pip install --editable . --verbose --no-build-isolation --config-settings editable-verbose=true; then
+        echo "------------------$PACKAGE_NAME:build_fails---------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Build_Fails"
+        exit 1
+else
+        echo "------------------$PACKAGE_NAME:build_success-------------------------"
+        echo "$PACKAGE_VERSION $PACKAGE_NAME"
+        echo "$PACKAGE_NAME  | $PACKAGE_VERSION | $OS_NAME | GitHub  | Pass |  Build_Success"
+fi
+
+python3.11 -m pip show scikit-learn
+python3.11 -c "import sklearn; sklearn.show_versions()"
+
+if [ $? == 0 ]; then
+     echo "------------------$PACKAGE_NAME::Install_Success---------------------"
+     echo "$PACKAGE_VERSION $PACKAGE_NAME"
+     echo "$PACKAGE_NAME  | $PACKAGE_URL | $PACKAGE_VERSION  | Pass |  Install_Success"
+else
+     echo "------------------$PACKAGE_NAME::Install_Fail-------------------------"
+     echo "$PACKAGE_VERSION $PACKAGE_NAME"
+     echo "$PACKAGE_NAME  | $PACKAGE_URL | $PACKAGE_VERSION  | Fail |  Install_Fail"
+     exit 2
+fi
+
+# test using pytest - set below flag as suggested in GitHub forums to resolve ImportPathMismatchError
+export PY_IGNORE_IMPORTMISMATCH=1
+if ! pytest sklearn/tests/test_common.py ; then
+        echo "------------------$PACKAGE_NAME:test_fails---------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME "
+        echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | Github | Fail |  Test_Fails"
+        exit 2
+else
+        echo "------------------$PACKAGE_NAME:test_success-------------------------"
+        echo "$PACKAGE_URL $PACKAGE_NAME "
+        echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | Github | Pass |  Test_Success"
+	exit 0
+fi


### PR DESCRIPTION
scikit-learn_ubi_8.10.sh - build scikit-learn==1.5.0 .whl file(Maximo deliverable, along with numpy==2.1.2 and scipy==1.14.1 .whl files) with Python3.11, install .whl and test. Script to be run in UBI 8.10 container. Travis check set to False.
scikit-learn_ubi_9.3.sh - build scikit-learn==1.5.2 with Python3.11, install and test - part of Currency task. Script to be run in UBI 9.3 container. Travis check set to True.
build_info.json   - build info for scipy_ubi_9.3.sh as per Currency process.