### PR TITLE
Modified Go package version to fix CVE for Maximo.

### DIFF
--- a/f/filebeat/filebeat_ubi_8.10.sh
+++ b/f/filebeat/filebeat_ubi_8.10.sh
@@ -45,7 +45,7 @@ rustup default ${RUST_VERSION}
 rustc --version | grep "${RUST_VERSION}"
 
 # Install go
-export GO_VERSION=${GO_VERSION:-1.22.1}
+export GO_VERSION=${GO_VERSION:-1.22.9}
 export GOROOT=${GOROOT:-"/usr/local/go"}
 export GOPATH=${GOPATH:-$HOME/go}
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin:/usr/local/bin


### PR DESCRIPTION
Fix CVE in stdlib package with higher Go version, as suggested by Grype tool.