### PR TITLE
Ansible Event Driven Repo 2.6.0 - Build Script updates

### DIFF
--- a/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
+++ b/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
@@ -24,7 +24,6 @@ PACKAGE_VERSION=${1:-v2.6.0}
 yum install java-17-openjdk java-17-openjdk-devel java-17-openjdk-headless openssl-devel sudo git wget tar python3-devel python3-pip gcc gcc-c++ cmake.ppc64le systemd-devel zlib-devel krb5-devel rust cargo maven -y
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.14.0.7-2.el9.ppc64le
 export PATH=$PATH:$JAVA_HOME/bin:$HOME/.cargo/bin:$PATH
-ln -s /usr/local/apache-maven-3.8.7/bin/mvn /usr/bin/mvn
 
 mkdir -p ansible_collections/ansible
 git clone $PACKAGE_URL

--- a/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
+++ b/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
@@ -2,13 +2,13 @@
 # ---------------------------------------------------------------------
 #
 # Package       : event-driven-ansible
-# Version       : v2.0.0
+# Version       : v2.6.0
 # Source repo   : https://github.com/ansible/event-driven-ansible/
 # Tested on     : UBI:9.3
 # Language      : Python
 # Travis-Check  : True
 # Script License: Apache License, Version 2 or later
-# Maintainer    : Ashwini Kadam <Ashwini.Kadam@ibm.com>,Vinod K <Vinod.K1@ibm.com>
+# Maintainer    : Ashwini Kadam <Ashwini.Kadam@ibm.com>,Neha Avhad <Neha.Avhad1@ibm.com>
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.
@@ -19,37 +19,32 @@
 # ---------------------------------------------------------------------
 PACKAGE_NAME=event-driven-ansible
 PACKAGE_URL=https://github.com/ansible/event-driven-ansible/
-PACKAGE_VERSION=${1:-v2.0.0}
+PACKAGE_VERSION=${1:-v2.6.0}
 
-yum install java-17-openjdk java-17-openjdk-devel java-17-openjdk-headless openssl-devel sudo git wget tar python-devel python3-pip gcc gcc-c++ cmake.ppc64le systemd-devel zlib-devel -y
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-export PATH=$PATH:$JAVA_HOME/bin
-
-#Install rust
-wget https://static.rust-lang.org/dist/rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
-tar -xzf rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
-cd rust-1.75.0-powerpc64le-unknown-linux-gnu
-sudo ./install.sh
-export PATH=$HOME/.cargo/bin:$PATH
-cd ../
-
-#Install maven
-wget https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz
-tar -zxf apache-maven-3.8.7-bin.tar.gz
-cp -R apache-maven-3.8.7 /usr/local
+yum install java-17-openjdk java-17-openjdk-devel java-17-openjdk-headless openssl-devel sudo git wget tar python3-devel python3-pip gcc gcc-c++ cmake.ppc64le systemd-devel zlib-devel krb5-devel rust cargo maven -y
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.14.0.7-2.el9.ppc64le
+export PATH=$PATH:$JAVA_HOME/bin:$HOME/.cargo/bin:$PATH
 ln -s /usr/local/apache-maven-3.8.7/bin/mvn /usr/bin/mvn
-    
+
 mkdir -p ansible_collections/ansible
 git clone $PACKAGE_URL
 mv event-driven-ansible ansible_collections/ansible/eda
+
 cd ansible_collections/ansible/eda
 git checkout $PACKAGE_VERSION
+
+# Update tox.ini to add JAVA_HOME
+sed -i '/passenv =/ i\    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.14.0.7-2.el9.ppc64le' tox.ini
+# To assume no changes in files/folders
+git update-index --assume-unchanged tox.ini
+git update-index --assume-unchanged ansible_collections/
+git update-index --assume-unchanged event-driven-ansible/
+
 sudo dnf remove -y python3-chardet
 python3 -m pip install --upgrade pip setuptools wheel tox
 python3 -m pip install -r requirements.txt
 
-
-if ! python3 -m pip install -r test_requirements.txt ; then
+if ! python3 -m pip install -r requirements.txt ; then
      echo "------------------$PACKAGE_NAME:Build_fails---------------------"
      echo "$PACKAGE_VERSION $PACKAGE_NAME"
      echo "$PACKAGE_NAME  | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Build_Fails_"

--- a/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
+++ b/a/ansible-event-driven-ansible/event-driven-ansible_ubi_9.3.sh
@@ -17,6 +17,7 @@
 #             contact "Maintainer" of this script.
 #
 # ---------------------------------------------------------------------
+
 PACKAGE_NAME=event-driven-ansible
 PACKAGE_URL=https://github.com/ansible/event-driven-ansible/
 PACKAGE_VERSION=${1:-v2.6.0}


### PR DESCRIPTION
Updated build script for Ansible Event Driven Repo Version 2.6.0.
Tested the script on UBI 9.3. Please find attached logs for successful execution. [output.log]
[output.log.txt](https://github.com/user-attachments/files/19340508/output.log.txt)


