### PR TITLE
ODH: Fix missing libclang shared libraries in outlines-core build script

### DIFF
--- a/o/outlines-core/outlines_core_ubi_9_3.sh
+++ b/o/outlines-core/outlines_core_ubi_9_3.sh
@@ -55,6 +55,10 @@ fi
 
 git checkout $PACKAGE_VERSION
 
+# Patch pyproject.toml with fixing versioning
+echo "Updating pyproject.toml with version $PACKAGE_VERSION..."
+sed -i '/^name = /a version = "'"$PACKAGE_VERSION"'"' pyproject.toml
+
 # Configure OpenSSL environment variables
 export OPENSSL_DIR=/usr
 export OPENSSL_LIB_DIR=/usr/lib64

--- a/o/outlines-core/outlines_core_ubi_9_3.sh
+++ b/o/outlines-core/outlines_core_ubi_9_3.sh
@@ -57,6 +57,10 @@ git checkout $PACKAGE_VERSION
 
 # Patch pyproject.toml with fixing versioning
 echo "Updating pyproject.toml with version $PACKAGE_VERSION..."
+
+# Remove any existing 'dynamic = ["version"]' line
+sed -i '/dynamic = \["version"\]/d' pyproject.toml
+# Insert 'version = "<PACKAGE_VERSION>"'
 sed -i '/^name = /a version = "'"$PACKAGE_VERSION"'"' pyproject.toml
 
 # Configure OpenSSL environment variables

--- a/o/outlines-core/outlines_core_ubi_9_3.sh
+++ b/o/outlines-core/outlines_core_ubi_9_3.sh
@@ -60,6 +60,10 @@ echo "Updating pyproject.toml with version $PACKAGE_VERSION..."
 
 # Remove any existing 'dynamic = ["version"]' line
 sed -i '/dynamic = \["version"\]/d' pyproject.toml
+
+# Remove any existing 'version =' line to avoid duplicates
+sed -i '/^version = /d' pyproject.toml
+
 # Insert 'version = "<PACKAGE_VERSION>"'
 sed -i '/^name = /a version = "'"$PACKAGE_VERSION"'"' pyproject.toml
 

--- a/o/outlines-core/outlines_core_ubi_9_3.sh
+++ b/o/outlines-core/outlines_core_ubi_9_3.sh
@@ -29,12 +29,15 @@ OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
 echo "Installing dependencies..."
 dnf update -y
 dnf install -y git gcc-toolset-13 make python${PYTHON_VERSION} python${PYTHON_VERSION}-devel \
-               python${PYTHON_VERSION}-pip openssl openssl-devel
+               python${PYTHON_VERSION}-pip openssl openssl-devel \
+               llvm llvm-devel clang clang-devel cmake
+
 source /opt/rh/gcc-toolset-13/enable
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source $HOME/.cargo/env
 
+export LIBCLANG_PATH=/usr/lib64
 
 # Clone the repository
 if [ -d "$PACKAGE_NAME" ]; then


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
