### PR TITLE
Fix issue with export of /proj.4/build/lib path that caused failure on Currency portal.

### DIFF
--- a/p/pyproj/pyproj_ubi_9.3.sh
+++ b/p/pyproj/pyproj_ubi_9.3.sh
@@ -52,10 +52,10 @@ git submodule update --init
 python3.11 -m venv pyproj-env
 source pyproj-env/bin/activate
 
-export PROJ_DIR=../proj.4/build
-export PROJ_LIBDIR=../proj.4/build/lib
-export PROJ_INCDIR=../proj.4/src
-export PROJ_DATA=/proj.4/build/data
+export PROJ_DIR=$HOME_DIR/proj.4/build
+export PROJ_LIBDIR=$HOME_DIR/proj.4/build/lib
+export PROJ_INCDIR=$HOME_DIR/proj.4/src
+export PROJ_DATA=$HOME_DIR/proj.4/build/data
 
 # build and install
 if ! python3 -m pip install . ; then


### PR DESCRIPTION
Use $HOME to export the lib path, relative to home directory instead of root directory.