### PR TITLE
Fix build issue on Currency portal and fine-tune build script.

### DIFF
--- a/s/shapely/build_info.json
+++ b/s/shapely/build_info.json
@@ -3,6 +3,7 @@
   "package_name": "shapely",
   "github_url": "https://github.com/shapely/shapely.git",
   "version": "1.8.5",
+  "wheel_build" : true,
   "default_branch": "main",
   "package_dir": "s/shapely",
   "build_script": "shapely_ubi_9.3.sh",


### PR DESCRIPTION
1. Fix issue _shapely/_geometry_helpers.c:1272:10: fatal error: c_api.h: No such file or directory_ seen on Currency Portal.
2. Fine-tune the build script to make it compatible with Currency portal build structure.
3. Add wheel_build flag to build.json file.
