### PR TITLE
Removing -e flag from pip install in grpcio

### DIFF
--- a/g/grpcio/grpcio_1.70.0_ubi_9.5.sh
+++ b/g/grpcio/grpcio_1.70.0_ubi_9.5.sh
@@ -38,7 +38,7 @@ export GRPC_PYTHON_BUILD_WITH_CYTHON=1
 export PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 
 # Install the package
-pip3 install -e .
+pip3 install .
 
 if [ $? == 0 ]; then
      echo "------------------$PACKAGE_NAME::Build_Pass---------------------"


### PR DESCRIPTION
Grpcio 1.72.0 fails with wrapper script when -e flag is passed in `pip install` command. Hence removing it to work with wrapper script. (https://github.com/ppc64le/build-scripts/blob/master/script/create_wheel_wrapper.sh)
