### PR TITLE
Limit docker build output

### DIFF
--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -70,7 +70,7 @@ if [ $build_docker != false ];then
         fi
         exit 1
     else
-        if [ $build_size -lt 1800000 ];
+        if [ $docker_build_size -lt 1800000 ];
         then
            cat docker_build.log
         else

--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -49,7 +49,14 @@ if [ $build_docker != false ];then
     echo "Building docker image"
     echo "sudo docker build $build_args -t $image_name $docker_builddir"
     echo "*************************************************************************************"
-    sudo docker build $build_args -t $image_name $docker_builddir
+    sudo docker build $build_args -t $image_name $docker_builddir > docker_build.log 2>&1
+    docker_build_size=$(stat -c %s build_log)
+    if [ $docker_build_size -lt 1800000 ];
+    then
+       cat docker_build.log
+    else
+       tail -300 docker_build.log
+    fi    
     docker save -o "$HOME/build/$TRAVIS_REPO_SLUG/image.tar" $image_name
 else
     echo "Docker image is not supported"

--- a/script/build_docker.sh
+++ b/script/build_docker.sh
@@ -49,7 +49,7 @@ if [ $build_docker != false ];then
     echo "Building docker image"
     echo "sudo docker build $build_args -t $image_name $docker_builddir"
     echo "*************************************************************************************"
-    sudo docker build $build_args -t $image_name $docker_builddir > docker_build.log 2>&1
+    sudo docker build $build_args -t $image_name $docker_builddir > docker_build.log 2>&1 &
     SCRIPT_PID=$!
     while ps -p $SCRIPT_PID > /dev/null
     do 

--- a/travis-currency-ymls/currency-build.yml
+++ b/travis-currency-ymls/currency-build.yml
@@ -6,8 +6,6 @@ language: shell
 branches:
   only:
     - master
-    - python-ecosystem
-    - limit_docker_build_output
 
 env:
   global:

--- a/travis-currency-ymls/currency-build.yml
+++ b/travis-currency-ymls/currency-build.yml
@@ -7,6 +7,7 @@ branches:
   only:
     - master
     - python-ecosystem
+    - limit_docker_build_output
 
 env:
   global:


### PR DESCRIPTION
output the docker build logs to a file and printing the logs based on the file size, by that we will avoid log length limit exceeded error.