### PR TITLE
Correcting dir structure in export commands

### DIFF
--- a/t/torchaudio/torchaudio_ubi_9.3.sh
+++ b/t/torchaudio/torchaudio_ubi_9.3.sh
@@ -268,17 +268,17 @@ export USE_FFMPEG=OFF
 export BUILD_SOX=OFF
 export USE_OPENMP=OFF
 export BUILD_TORCHAUDIO_PYTHON_EXTENSION=ON
-export LIBPROTO_INSTALL=/protobuf/local/libprotobuf
+export LIBPROTO_INSTALL=${SCRIPT_DIR}/protobuf/local/libprotobuf
 export Protobuf_INCLUDE_DIR=${LIBPROTO_INSTALL}/include
 export Protobuf_LIBRARIES=${LIBPROTO_INSTALL}/lib64
 export Protobuf_LIBRARY=${LIBPROTO_INSTALL}/lib64/libprotobuf.so
 export Protobuf_LITE_LIBRARY=${LIBPROTO_INSTALL}/lib64/libprotobuf-lite.so
 export Protobuf_PROTOC_EXECUTABLE=${LIBPROTO_INSTALL}/bin/protoc
-export LD_LIBRARY_PATH=/pytorch/torch/lib64/libprotobuf.so.3.13.0.0:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=/pytorch/build/lib/libprotobuf.so.3.13.0.0:$LD_LIBRARY_PATH
-export PATH="/protobuf/local/libprotobuf/bin/protoc:${PATH}"
-export LD_LIBRARY_PATH="/OpenBLAS:/protobuf/local/libprotobuf/lib64:${LD_LIBRARY_PATH}"
-export LD_LIBRARY_PATH="/protobuf/third_party/abseil-cpp/local/abseilcpp/lib:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH=${SCRIPT_DIR}/pytorch/torch/lib64/libprotobuf.so.3.13.0.0:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${SCRIPT_DIR}/pytorch/build/lib/libprotobuf.so.3.13.0.0:$LD_LIBRARY_PATH
+export PATH="${SCRIPT_DIR}/protobuf/local/libprotobuf/bin/protoc:${PATH}"
+export LD_LIBRARY_PATH="${SCRIPT_DIR}/OpenBLAS:/protobuf/local/libprotobuf/lib64:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${SCRIPT_DIR}/protobuf/third_party/abseil-cpp/local/abseilcpp/lib:${LD_LIBRARY_PATH}"
 
 echo "Installing torchaudio..."
 if ! (python3.12 -m pip install -v . --no-build-isolation --no-deps);then


### PR DESCRIPTION
Without these changes, torchaudio build is failing for both python 3.11 and 3.12 because of missing openblas and protobuf packages.
After making these changes, build is working fine both with and without wrapper script.