### PR TITLE
Modify torchvision script

### DIFF
--- a/t/torchvision/torchvision_ubi_9.3.sh
+++ b/t/torchvision/torchvision_ubi_9.3.sh
@@ -541,7 +541,7 @@ git clone $PACKAGE_URL
 cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 
-if ! (pip3.12 install -v -e . --no-build-isolation); then
+if ! (python3.12 -m pip install -v . --no-build-isolation); then
     echo "------------------$PACKAGE_NAME:install_fails-------------------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Install_Fails"
@@ -549,7 +549,7 @@ if ! (pip3.12 install -v -e . --no-build-isolation); then
 fi
 
 cd $CURRENT_DIR
-pip3.12 install pytest pytest-xdist
+python3.12 -m pip install pytest pytest-xdist
 
 if ! pytest $PACKAGE_NAME/test/common_extended_utils.py $PACKAGE_NAME/test/common_utils.py $PACKAGE_NAME/test/smoke_test.py $PACKAGE_NAME/test/test_architecture_ops.py $PACKAGE_NAME/test/test_datasets_video_utils_opt.py ; then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"


### PR DESCRIPTION
Without these changes torchvision installation is failing with wrapper script for python version3.11 due to following error:
```
------------------Building torchvision------------------------
Cloning into 'vision'...
remote: Enumerating objects: 641091, done.
remote: Counting objects: 100% (1146/1146), done.
remote: Compressing objects: 100% (947/947), done.
remote: Total 641091 (delta 913), reused 233 (delta 194), pack-reused 639945 (from 3)
Receiving objects: 100% (641091/641091), 1.18 GiB | 57.79 MiB/s, done.
Resolving deltas: 100% (599649/599649), done.
Note: switching to 'v0.21.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 7af698794e [Cherry-Pick] Update Requires-Python: >=3.9 (#8886)
temp_build_script.sh: line 544: pip3.12: command not found
------------------vision:install_fails-------------------------------------
https://github.com/pytorch/vision.git vision
vision  |  https://github.com/pytorch/vision.git | v0.21.0 | "Red Hat Enterprise Linux 9.3 (Plow)" | GitHub | Fail |  Install_Fails
```
