### PR TITLE
Fixed issues  with hf-xet  to support other python version apart from default

### DIFF
--- a/h/hf-xet/hf-xet_ubi_9.3.sh
+++ b/h/hf-xet/hf-xet_ubi_9.3.sh
@@ -42,14 +42,14 @@ cd $PACKAGE_DIR
 git checkout $PACKAGE_VERSION
 
 #install python dependencies
-pip3.12 install numpy cython build pytest
+python3.12 -m pip install numpy cython build pytest
 
 sed -i "s/^version *= *.*/version = \"${PACKAGE_VERSION#v}\"/" Cargo.toml
 
-pip3.12 install maturin build wheel
+python3.12 -m pip install maturin build wheel
 
 #install
-if ! pip3.12 install -e . ; then
+if ! python3.12 -m pip install -e . ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
