### PR TITLE
Currency: Updated build_info.json as required version is unavailable in currency portal

### DIFF
--- a/e/executing/build_info.json
+++ b/e/executing/build_info.json
@@ -2,6 +2,7 @@
   "maintainer": "kiranNukal",
   "package_name": "executing",
   "github_url": "https://github.com/alexmojaki/executing",
+  "required_versions":{"Releases": ["*"], "Tags": ["v2.2.0"]}, 
   "version": "v2.2.0",
   "wheel_build" : true,
   "default_branch": "master",


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
