### PR TITLE
Update build script to build latest h5py==3.14.0

### DIFF
--- a/h/h5py/h5py_3.13.0_ubi_9.3.sh
+++ b/h/h5py/h5py_3.13.0_ubi_9.3.sh
@@ -127,7 +127,7 @@ python3.12 -m pip install .
 cd $CURRENT_DIR
 git clone https://github.com/h5py/h5py.git
 cd h5py/
-git checkout 3.13.0
+git checkout $PACKAGE_VERSION
 
 python3.12 -m pip install Cython==0.29.36
 python3.12 -m pip install numpy==2.0.2


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
