### PR TITLE
Fix wheel build of htpasswd package

### DIFF
--- a/h/htpasswd/htpasswd_ubi_9.3.sh
+++ b/h/htpasswd/htpasswd_ubi_9.3.sh
@@ -56,6 +56,10 @@ fi
 # build wheel
 python3.11 -m pip install wheel
 
+if [ ${PACKAGE_VERSION} = "master" ]; then
+  PACKAGE_VERSION=2.3
+fi
+
 if ! python3.11 -m pip wheel --no-deps htpasswd==${PACKAGE_VERSION}; then
     echo "--------------------$PACKAGE_NAME:wheel_build_fails----------------------------------------"
     exit 2


### PR DESCRIPTION
Build the correct version of htpasswd with wheel
command. Building version 2.3 of htpasswd requires building from the master branch of the GitHub
repository. Fixes htpasswd build failures.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
