### PR TITLE
Protobuf pin to 4.25.8 

### DIFF
--- a/g/grpc-cpp/grpc-cpp_ubi_9.3.sh
+++ b/g/grpc-cpp/grpc-cpp_ubi_9.3.sh
@@ -104,7 +104,7 @@ export CXX_COMPILER=$(which g++)
 
 git clone https://github.com/protocolbuffers/protobuf
 cd protobuf
-git checkout v4.25.3
+git checkout v4.25.8
 
 LIBPROTO_DIR=$(pwd)
 mkdir -p $LIBPROTO_DIR/local/libprotobuf

--- a/g/grpcio/grpcio_1.70.0_ubi_9.5.sh
+++ b/g/grpcio/grpcio_1.70.0_ubi_9.5.sh
@@ -31,7 +31,7 @@ cd $PACKAGE_NAME/
 git checkout $PACKAGE_VERSION
 git submodule update --init --recursive
 
-pip3 install setuptools coverage cython protobuf==4.25.3 wheel cmake==3.*
+pip3 install setuptools coverage cython protobuf==4.25.8 wheel cmake==3.*
 
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true
 export GRPC_PYTHON_BUILD_WITH_CYTHON=1

--- a/o/onnx/onnx_ubi_9.3.sh
+++ b/o/onnx/onnx_ubi_9.3.sh
@@ -138,7 +138,7 @@ LIBPROTO_INSTALL=$LIBPROTO_DIR/local/libprotobuf
 # Clone Source-code
 echo " ------------------------------------------ Libprotobuf Installing ------------------------------------------ "
 
-PACKAGE_VERSION_LIB="v4.25.3"
+PACKAGE_VERSION_LIB="v4.25.8"
 PACKAGE_GIT_URL="https://github.com/protocolbuffers/protobuf"
 git clone $PACKAGE_GIT_URL -b $PACKAGE_VERSION_LIB
 
@@ -208,9 +208,9 @@ git checkout $PACKAGE_VERSION
 git submodule update --init --recursive
 sed -i 's|https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz%7Chttps://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz%7Cg' CMakeLists.txt && \
 sed -i 's|e21faa0de5afbbf8ee96398ef0ef812daf416ad8|bb8a766f3aef8e294a864104b8ff3fc37b393210|g' CMakeLists.txt && \
-sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz%7Chttps://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.3.tar.gz%7Cg' CMakeLists.txt && \
-sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|4ba37c659f85c20abb0cc595bfac5e3a385e8e93|g' CMakeLists.txt && \
-sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.3")|g' CMakeLists.txt
+sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz%7Chttps://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.8.tar.gz%7Cg' CMakeLists.txt && \
+sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|ffa977b9a7fb7e6ae537528eeae58c1c4d661071|g' CMakeLists.txt && \
+sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.8")|g' CMakeLists.txt
 
 export ONNX_ML=1
 export ONNX_PREFIX=$(pwd)/../onnx-prefix

--- a/o/onnxmltools/onnxmltools_ubi_9.3.sh
+++ b/o/onnxmltools/onnxmltools_ubi_9.3.sh
@@ -125,7 +125,7 @@ echo "LIBPROTO_INSTALL set to $LIBPROTO_INSTALL"
 echo " --------------------------------------------------- Libprotobuf Installing --------------------------------------------------- "
 
 # Clone Source-code
-PACKAGE_VERSION_LIB="v4.25.3"
+PACKAGE_VERSION_LIB="v4.25.8"
 PACKAGE_GIT_URL="https://github.com/protocolbuffers/protobuf"
 git clone $PACKAGE_GIT_URL -b $PACKAGE_VERSION_LIB
 
@@ -205,9 +205,9 @@ git submodule update --init --recursive
 
 sed -i 's|https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz|https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz|g' CMakeLists.txt && \
 sed -i 's|e21faa0de5afbbf8ee96398ef0ef812daf416ad8|bb8a766f3aef8e294a864104b8ff3fc37b393210|g' CMakeLists.txt && \
-sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz|https://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.3.tar.gz|g' CMakeLists.txt && \
-sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|4ba37c659f85c20abb0cc595bfac5e3a385e8e93|g' CMakeLists.txt && \
-sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.3")|g' CMakeLists.txt
+sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz|https://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.8.tar.gz|g' CMakeLists.txt && \
+sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|ffa977b9a7fb7e6ae537528eeae58c1c4d661071|g' CMakeLists.txt && \
+sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.8")|g' CMakeLists.txt
 
 export ONNX_ML=1
 export ONNX_PREFIX=$(pwd)/../onnx-prefix

--- a/o/onnxruntime/onnxruntime_1.21.0_ubi_9.3.sh
+++ b/o/onnxruntime/onnxruntime_1.21.0_ubi_9.3.sh
@@ -134,7 +134,7 @@ LIBPROTO_INSTALL=$(pwd)/local/libprotobuf
 echo "LIBPROTO_INSTALL set to $LIBPROTO_INSTALL"
 
 # Clone Source-code
-PACKAGE_VERSION_LIB="v4.25.3"
+PACKAGE_VERSION_LIB="v4.25.8"
 PACKAGE_GIT_URL="https://github.com/protocolbuffers/protobuf"
 git clone $PACKAGE_GIT_URL -b $PACKAGE_VERSION_LIB
 
@@ -205,9 +205,9 @@ git submodule update --init --recursive
 
 sed -i 's|https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.3.tar.gz|https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz|g' CMakeLists.txt && \
 sed -i 's|e21faa0de5afbbf8ee96398ef0ef812daf416ad8|bb8a766f3aef8e294a864104b8ff3fc37b393210|g' CMakeLists.txt && \
-sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz|https://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.3.tar.gz|g' CMakeLists.txt && \
-sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|4ba37c659f85c20abb0cc595bfac5e3a385e8e93|g' CMakeLists.txt && \
-sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.3")|g' CMakeLists.txt
+sed -i 's|https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.tar.gz|https://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.8.tar.gz|g' CMakeLists.txt && \
+sed -i 's|310938afea334b98d7cf915b099ec5de5ae3b5c5|ffa977b9a7fb7e6ae537528eeae58c1c4d661071|g' CMakeLists.txt && \
+sed -i 's|set(Protobuf_VERSION "4.22.3")|set(Protobuf_VERSION "v4.25.8")|g' CMakeLists.txt
 
 export ONNX_ML=1
 export ONNX_PREFIX=$(pwd)/../onnx-prefix
@@ -238,7 +238,7 @@ python3 -m pip install cython meson
 python3 -m pip install numpy==2.0.2
 python3 -m pip install parameterized
 python3 -m pip install pytest nbval pythran mypy-protobuf
-python3 -m pip install scipy==1.13.1
+python3 -m pip install scipy==1.15.2
 
 python3 setup.py install
 

--- a/o/opencv-python-headless/opencv-python-headless_ubi_9.3.sh
+++ b/o/opencv-python-headless/opencv-python-headless_ubi_9.3.sh
@@ -104,7 +104,7 @@ export CXX_COMPILER=$(which g++)
 echo "----------------protobuf installing-------------------"
 git clone https://github.com/protocolbuffers/protobuf
 cd protobuf
-git checkout v4.25.3
+git checkout v4.25.8
 
 LIBPROTO_DIR=$(pwd)
 mkdir -p $LIBPROTO_DIR/local/libprotobuf

--- a/o/orc/orc_ubi_9.3.sh
+++ b/o/orc/orc_ubi_9.3.sh
@@ -102,7 +102,7 @@ echo " --------------------------------------------------- Cloning protobuf ----
 
 git clone https://github.com/protocolbuffers/protobuf
 cd protobuf
-git checkout v4.25.3
+git checkout v4.25.8
 git submodule update --init --recursive
 rm -rf ./third_party/googletest | true
 rm -rf ./third_party/abseil-cpp | true

--- a/p/pyarrow/pyarrow_19.0.0_ubi_9.3.sh
+++ b/p/pyarrow/pyarrow_19.0.0_ubi_9.3.sh
@@ -282,7 +282,7 @@ export CXX_COMPILER=$(which g++)
 #Build libprotobuf
 git clone https://github.com/protocolbuffers/protobuf
 cd protobuf
-git checkout v4.25.3
+git checkout v4.25.8
 
 LIBPROTO_DIR=$(pwd)
 mkdir -p $LIBPROTO_DIR/local/libprotobuf


### PR DESCRIPTION
In this PR:
- Updated the protobuf version to 4.25.8
- Corrections in numpy, scipy pins numpy==2.0.2 and scipy==1.15.2

Git issue:
- https://github.ibm.com/open-ce/opence-pip-packaging/issues/621

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
