### PR TITLE
changed protobuf build-info to used 4.25.3 script as default

### DIFF
--- a/p/protobuf/build_info.json
+++ b/p/protobuf/build_info.json
@@ -21,7 +21,7 @@
     "build_script": "protobuf_v4.25.3_ubi_9.3.sh"
   },
   "*": {
-  "build_script": "protobuf_ubi_9.3.sh"
+  "build_script": "protobuf_v4.25.3_ubi_9.3.sh"
   }
 }
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [x] Did you have **Legal approvals** for patch files ? 
