### PR TITLE
Set ENABLE_HEADLESS, to build headless version of opencv-python.

### DIFF
--- a/o/opencv-python-headless/opencv-python-headless_4.10.0.84_ubi_9.3.sh
+++ b/o/opencv-python-headless/opencv-python-headless_4.10.0.84_ubi_9.3.sh
@@ -302,6 +302,8 @@ cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 git submodule update --init
 
+export ENABLE_HEADLESS=1
+
 export CMAKE_PREFIX_PATH="$PREFIX/abseilcpp;$PREFIX/libprotobuf";
 
 export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release

--- a/o/opencv-python-headless/opencv-python-headless_ubi_9.3.sh
+++ b/o/opencv-python-headless/opencv-python-headless_ubi_9.3.sh
@@ -167,7 +167,7 @@ cd $PACKAGE_DIR
 git checkout $PACKAGE_VERSION
 git submodule update --init --recursive
 
-sed -i "s/^[[:space:]]*name=package_name/name=\"${PACKAGE_NAME}\"/" setup.py
+export ENABLE_HEADLESS=1
 
 export CMAKE_PREFIX_PATH="$ABSEILCPP_PREFIX;$LIBPROTOBUF_PREFIX"
 export CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Fix issue mentioned on https://github.ibm.com/ppc64le-automation/python-ecosystem/issues/589#issuecomment-118346766
