### PR TITLE
Added array_record v0.8.1 patch

### DIFF
--- a/a/array_record/array_record_0.8.1.patch
+++ b/a/array_record/array_record_0.8.1.patch
@@ -1,0 +1,418 @@
+diff --git a/Add-hh_vsx-deps-for-highwayhash_dynamic.patch b/Add-hh_vsx-deps-for-highwayhash_dynamic.patch
+new file mode 100644
+index 0000000..1cd24a9
+--- /dev/null
++++ b/Add-hh_vsx-deps-for-highwayhash_dynamic.patch
+@@ -0,0 +1,332 @@
++diff --git a/MODULE.bazel b/MODULE.bazel
++index 82718d69..2db9abca 100644
++--- a/MODULE.bazel
+++++ b/MODULE.bazel
++@@ -30,10 +30,6 @@ bazel_dep(
++     name = "bzip2",
++     version = "1.0.8",
++ )
++-bazel_dep(
++-    name = "highwayhash",
++-    version = "0.0.0-20240305-5ad3bf8",
++-)
++ bazel_dep(
++     name = "lz4",
++     version = "1.9.4",
++@@ -69,6 +65,316 @@ bazel_dep(
++     repo_name = "net_zstd",
++ )
++
+++http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+++http_archive(
+++    name = "highwayhash",
+++    sha256 = "8be5e0af6ede048c54c8355e0d7bb87305531021d19b1f6334d5c16edb290c81",
+++    strip_prefix = "highwayhash-5ad3bf8444cfc663b11bf367baaa31f36e7ff7c8",
+++    urls = ["https://github.com/google/highwayhash/archive/5ad3bf8444cfc663b11bf367baaa31f36e7ff7c8.zip"],
+++    build_file_content = """
+++package(
+++    default_visibility = ["//visibility:public"],
+++    features = ["header_modules"],
+++)
+++
+++licenses(["notice"])
+++
+++config_setting(
+++    name = "haswell",
+++    values = {"cpu": "haswell"},
+++)
+++
+++config_setting(
+++    name = "k8",
+++    values = {"cpu": "k8"},
+++)
+++
+++config_setting(
+++    name = "cpu_ppc",
+++    values = {"cpu": "ppc"},
+++)
+++
+++config_setting(
+++    name = "cpu_aarch64",
+++    values = {"cpu": "aarch64"},
+++)
+++
+++config_setting(
+++    name = "cpu_darwin_arm64",
+++    values = {"cpu": "darwin_arm64"},
+++)
+++
+++#-----------------------------------------------------------------------------
+++# Platform-specific
+++
+++cc_library(
+++    name = "compiler_specific",
+++    hdrs = ["highwayhash/compiler_specific.h"],
+++)
+++
+++cc_library(
+++    name = "arch_specific",
+++    srcs = ["highwayhash/arch_specific.cc"],
+++    hdrs = ["highwayhash/arch_specific.h"],
+++    deps = [":compiler_specific"],
+++)
+++
+++cc_library(
+++    name = "endianess",
+++    hdrs = ["highwayhash/endianess.h"],
+++)
+++
+++cc_library(
+++    name = "instruction_sets",
+++    srcs = ["highwayhash/instruction_sets.cc"],
+++    hdrs = ["highwayhash/instruction_sets.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++    ],
+++)
+++
+++cc_library(
+++    name = "iaca",
+++    hdrs = ["highwayhash/iaca.h"],
+++    deps = [":compiler_specific"],
+++)
+++
+++cc_library(
+++    name = "os_specific",
+++    srcs = ["highwayhash/os_specific.cc"],
+++    hdrs = ["highwayhash/os_specific.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++    ],
+++)
+++
+++#-----------------------------------------------------------------------------
+++# Vectors
+++
+++cc_library(
+++    name = "scalar",
+++    textual_hdrs = ["highwayhash/scalar.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++    ],
+++)
+++
+++cc_library(
+++    name = "vector128",
+++    textual_hdrs = ["highwayhash/vector128.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++    ],
+++)
+++
+++cc_library(
+++    name = "vector256",
+++    textual_hdrs = ["highwayhash/vector256.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++    ],
+++)
+++
+++#-----------------------------------------------------------------------------
+++# SipHash
+++
+++cc_library(
+++    name = "sip_hash",
+++    srcs = ["highwayhash/sip_hash.cc"],
+++    hdrs = [
+++        "highwayhash/sip_hash.h",
+++        "highwayhash/state_helpers.h",
+++    ],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":endianess",
+++    ],
+++)
+++
+++#-----------------------------------------------------------------------------
+++# HighwayHash
+++
+++cc_library(
+++    name = "hh_types",
+++    hdrs = ["highwayhash/hh_types.h"],
+++    deps = [":instruction_sets"],
+++)
+++
+++cc_library(
+++    name = "load3",
+++    textual_hdrs = ["highwayhash/load3.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":endianess",
+++    ],
+++)
+++
+++cc_library(
+++    name = "hh_avx2",
+++    srcs = ["highwayhash/hh_avx2.cc"],
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    copts = select({
+++        ":k8": ["-mavx2"],
+++        ":haswell": ["-mavx2"],
+++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
+++    }),
+++    textual_hdrs = [
+++        "highwayhash/hh_avx2.h",
+++        "highwayhash/highwayhash_target.cc",
+++        "highwayhash/highwayhash.h",
+++        "highwayhash/hh_buffer.h",
+++    ],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":iaca",
+++        ":load3",
+++        ":vector128",
+++        ":vector256",
+++    ],
+++)
+++
+++cc_library(
+++    name = "hh_sse41",
+++    srcs = ["highwayhash/hh_sse41.cc"],
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    copts = select({
+++        ":k8": ["-msse4.1"],
+++        ":haswell": ["-msse4.1"],
+++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
+++    }),
+++    textual_hdrs = [
+++        "highwayhash/hh_sse41.h",
+++        "highwayhash/highwayhash_target.cc",
+++        "highwayhash/highwayhash.h",
+++        "highwayhash/hh_buffer.h",
+++    ],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":iaca",
+++        ":load3",
+++        ":vector128",
+++    ],
+++)
+++
+++cc_library(
+++    name = "hh_neon",
+++    srcs = [
+++        "highwayhash/hh_neon.cc",
+++        "highwayhash/vector_neon.h",
+++    ],
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    copts = select({
+++        ":cpu_aarch64": [],
+++        ":cpu_darwin_arm64": [],
+++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
+++    }),
+++    textual_hdrs = [
+++        "highwayhash/highwayhash_target.cc",
+++        "highwayhash/highwayhash.h",
+++        "highwayhash/hh_buffer.h",
+++        "highwayhash/hh_neon.h",
+++    ],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":load3",
+++    ],
+++)
+++
+++cc_library(
+++    name = "hh_vsx",
+++    srcs = ["highwayhash/hh_vsx.cc"],
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    textual_hdrs = [
+++        "highwayhash/highwayhash_target.cc",
+++        "highwayhash/highwayhash.h",
+++        "highwayhash/hh_buffer.h",
+++        "highwayhash/hh_vsx.h",
+++    ],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":load3",
+++    ],
+++)
+++
+++cc_library(
+++    name = "hh_portable",
+++    srcs = ["highwayhash/hh_portable.cc"],
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    textual_hdrs = [
+++        "highwayhash/hh_portable.h",
+++        "highwayhash/highwayhash_target.cc",
+++        "highwayhash/highwayhash.h",
+++        "highwayhash/hh_buffer.h",
+++    ],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":iaca",
+++        ":load3",
+++        ":scalar",
+++    ],
+++)
+++
+++# For users of the HighwayHashT template
+++cc_library(
+++    name = "highwayhash",
+++    hdrs = ["highwayhash/highwayhash.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_types",
+++        ":hh_portable",
+++    ] + select({
+++        ":cpu_ppc": [":hh_vsx"],
+++        ":cpu_aarch64": [":hh_neon"],
+++        ":cpu_darwin_arm64": [":hh_neon"],
+++        "//conditions:default": [
+++            ":hh_avx2",
+++            ":hh_sse41",
+++            ":iaca",
+++        ],
+++    }),
+++)
+++
+++# For users of InstructionSets<HighwayHash> runtime dispatch
+++cc_library(
+++    name = "highwayhash_dynamic",
+++    hdrs = ["highwayhash/highwayhash_target.h"],
+++    deps = [
+++        ":arch_specific",
+++        ":compiler_specific",
+++        ":hh_portable",
+++        ":hh_types",
+++    ] + select({
+++        ":cpu_ppc": [":hh_vsx"],
+++        ":cpu_aarch64": [":hh_neon"],
+++        ":cpu_darwin_arm64": [":hh_neon"],
+++        "//conditions:default": [
+++            ":hh_avx2",
+++            ":hh_sse41",
+++        ],
+++    }),
+++)
+++""",
+++)
+++
++ # Configure hermetic Python toolchain
++ SUPPORTED_PYTHON_VERSIONS = [
++     "3.8",
+diff --git a/MODULE.bazel b/MODULE.bazel
+index b3d252d..ee66560 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -24,14 +24,25 @@ module(
+ bazel_dep(name = "rules_proto", version = "7.0.2")
+ bazel_dep(name = "rules_python", version = "0.37.0")
+ bazel_dep(name = "platforms", version = "0.0.10")
+-bazel_dep(name = "protobuf", version = "28.3")
++bazel_dep(name = "protobuf", version = "29.1")
+ bazel_dep(name = "googletest", version = "1.15.2")
+ bazel_dep(name = "abseil-cpp", version = "20240722.0")
+ bazel_dep(name = "abseil-py", version = "2.1.0")
+ bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
+ bazel_dep(name = "riegeli", version = "0.0.0-20241218-3385e3c")
+ bazel_dep(name = "pybind11_bazel", version = "2.12.0")
++bazel_dep(name = "rules_buf", version = "0.5.2", dev_dependency = True)
++buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
++buf.toolchains(version = "v1.57.0")
++use_repo(buf, "rules_buf_toolchains")
+
++git_override(
++    module_name = "riegeli",
++    remote = "https://github.com/google/riegeli.git",
++    commit = "3385e3cbc5c1a1380eb99b7cf0b021c1ae0b2c30",
++    patches = ["//:Add-hh_vsx-deps-for-highwayhash_dynamic.patch"],
++    patch_strip = 1,
++)
+ SUPPORTED_PYTHON_VERSIONS = [
+     "3.10",
+     "3.11",
+diff --git a/oss/build_whl.sh b/oss/build_whl.sh
+index 85e1cad..3e1fbf9 100755
+--- a/oss/build_whl.sh
++++ b/oss/build_whl.sh
+@@ -7,6 +7,8 @@
+ set -e -x
+
+ OUTPUT_DIR="${OUTPUT_DIR:-/tmp/array_record}"
++export PYTHON_VERSION="3.12"
++PYTHON_BIN=$(which python3.12)
+
+ function write_to_bazelrc() {
+   echo "$1" >> .bazelrc
+@@ -23,6 +25,8 @@ function main() {
+   write_to_bazelrc "test --action_env PYTHON_VERSION=${PYTHON_VERSION}"
+   write_to_bazelrc "test --test_timeout=300"
+
++  write_to_bazelrc "build --jobs=32"
++  write_to_bazelrc "test --jobs=16"
+   write_to_bazelrc "build -c opt"
+   write_to_bazelrc "build --cxxopt=-std=c++17"
+   write_to_bazelrc "build --host_cxxopt=-std=c++17"
+@@ -40,7 +44,7 @@ function main() {
+   bazel build ... --action_env MACOSX_DEPLOYMENT_TARGET='11.0' --action_env PYTHON_BIN_PATH="${PYTHON_BIN}"
+   bazel test --verbose_failures --test_output=errors ... --action_env PYTHON_BIN_PATH="${PYTHON_BIN}"
+
+-  DEST="/tmp/array_record/all_dist"
++  DEST="$CURRENT_DIR/array_record/dist"
+   # Create the directory, then do dirname on a non-existent file inside it to
+   # give us an absolute paths with tilde characters resolved to the destination
+   # directory.
+@@ -87,13 +91,13 @@ function main() {
+   echo $(date) : "=== Output wheel file is in: ${DEST}"
+
+   # Install ArrayRecord from the wheel and run smoke tests.
+-  $PYTHON_BIN -m pip install ${OUTPUT_DIR}/all_dist/array_record*.whl
++  $PYTHON_BIN -m pip install --force-reinstall --no-deps "$DEST"/array_record*.whl
+   $PYTHON_BIN -c 'import array_record'
+   $PYTHON_BIN -c 'from array_record.python import array_record_data_source'
+-  $PYTHON_BIN -m pip install jax tensorflow>=2.20.0 grain
++  #$PYTHON_BIN -m pip install jax tensorflow>=2.20.0 grain
+   # Re-enable the grain import test once the new version is released.
+   # $PYTHON_BIN oss/test_import_grain.py
+-  $PYTHON_BIN oss/test_import_tensorflow.py
++  #$PYTHON_BIN oss/test_import_tensorflow.py
+ }
+
+ main
+


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

In this PR:
- Added patch for array-record v0.8.1 (Add-hh_vsx-deps-for-highwayhash_dynamic.patch) to restore highwayhash Bazel build definitions and applied it to Riegeli via git_override() in MODULE.bazel.
- The patch restores the missing Bazel rules from an older Riegeli version and adds PowerPC `(:cpu_ppc → :hh_vsx)` support to fix build failures.
- Upgraded protobuf to v29.1 and updated build_whl.sh to use Python 3.12, add parallel build/test flags (--jobs), and adjust wheel output and install paths.
- Commented `import tensorflow` test as tesorflow >2.20 required, will include it when available.
- Git Issue: https://github.ibm.com/open-ce/opence-pip-packaging/issues/710