### PR TITLE
Update create_wheel_wrapper.sh

### DIFF
--- a/script/create_wheel_wrapper.sh
+++ b/script/create_wheel_wrapper.sh
@@ -191,7 +191,7 @@ fi
 echo "Processing Package with Python $PYTHON_VERSION"
 
 # Create and activate virtual environment
-VENV_DIR="$CURRENT_DIR/pyvenv_$PYTHON_VERSION"
+VENV_DIR="$(realpath -m "${CURRENT_DIR}/pyvenv_${PYTHON_VERSION}")"
 create_venv "$VENV_DIR" "$PYTHON_VERSION"
 
 echo "=============== Running package build-script starts =================="


### PR DESCRIPTION
Updated the wrapper script to resolve below issue:
'//pyvenv_3.10/lib/python3.10/site-packages/_pytest/runner.py' is not in the subpath of '/' OR one path is relative and the other is absolute.
This is issue is observed if the CURRENT_DIR=/ so while running test cases it fails.