### PR TITLE
Corrected the build script name typo for v1.20.1.

### DIFF
--- a/o/onnxruntime/build_info.json
+++ b/o/onnxruntime/build_info.json
@@ -14,7 +14,7 @@
         "build_script": "onnxruntime_ubi_9_3.sh"
      },
     "v1.20.1": {
-        "build_script": "onnxruntime_1.20.1_ubi_9_3.sh"
+        "build_script": "onnxruntime_1.20.1_ubi_9.3.sh"
      },
     "v1.21.0": {
         "build_script": "onnxruntime_1.21.0_ubi_9.3.sh"


### PR DESCRIPTION
Changed the filename in build_info.json from onnxruntime_1.20.1_ubi_9_3.sh to onnxruntime_1.20.1_ubi_9.3.sh to resolve Currency Portal build issue.
