### PR TITLE
Fix build script failure in gensim for python version other than 3.12

### DIFF
--- a/g/gensim/gensim_4.3.3_ubi_9.5.sh
+++ b/g/gensim/gensim_4.3.3_ubi_9.5.sh
@@ -32,7 +32,7 @@ yum install -y git gcc gcc-c++ wget atlas pkg-config openblas-devel atlas-devel 
 # Ensure Python 3.12 is installed
 dnf install -y python3.12 python3.12-pip python3.12-test python3.12-devel
 python3.12 --version
-pip3.12 --version
+python3.12 -m pip --version
 
 echo " ------------------------------------------ Openblas Installing ------------------------------------------ "
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
