### PR TITLE
fix build script for numba==0.63.0

### DIFF
--- a/n/numba/build_info.json
+++ b/n/numba/build_info.json
@@ -1,12 +1,12 @@
 {
-    "maintainer": "SakshiJain0302",
+    "maintainer": "Shivansh-ibm",
     "package_name": "numba",
     "github_url": "https://github.com/numba/numba",
-    "version": "0.62.0",
+    "version": "0.63.0",
     "required_versions":{"Releases": ["*"], "Tags": ["0.62.0dev0"]},
     "wheel_build" : true,
     "default_branch": "main",
-    "build_script": "numba_0.62.0_ubi_9.3.sh",
+    "build_script": "numba_0.63.0_ubi_9.3.sh",
     "package_dir": "n/numba",
     "validate_build_script": true,
     "use_non_root_user": false,
@@ -14,7 +14,10 @@
 	"0.57.0":{
 		"build_script": "numba_ubi_9.3.sh"
 	},
-	"*": {
+	"0.62.*": {
         "build_script": "numba_0.62.0_ubi_9.3.sh"
+    },
+    "*": {
+        "build_script": "numba_0.63.0_ubi_9.3.sh"
     }
 }

--- a/n/numba/numba_0.63.0_ubi_9.3.sh
+++ b/n/numba/numba_0.63.0_ubi_9.3.sh
@@ -1,0 +1,173 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : numba
+# Version       : 0.63.0
+# Source repo   : https://github.com/numba/numba
+# Tested on     : UBI:9.3
+# Language      : Python
+# Ci-Check  : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Shivansh Sharma <shivansh.s1@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on the given
+# platform using the mentioned version of the package.
+# It may not work as expected with newer versions of the
+# package and/or distribution. In such a case, please
+# contact the "Maintainer" of this script.
+#
+# -----------------------------------------------------------------------------
+
+PACKAGE_NAME=numba
+PACKAGE_VERSION=${1:-0.63.0}
+PACKAGE_URL=https://github.com/numba/numba
+PACKAGE_DIR=numba
+WORKING_DIR=$(pwd)
+NUMERIC_VERSION=$(echo "$PACKAGE_VERSION" | grep -oP '^\d+(\.\d+){0,2}')
+
+# Install necessary  dependencies
+
+yum install -y git make wget python3.12 python3.12-devel python3.12-pip gcc-toolset-13 
+export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib/gcc/ppc64le-redhat-linux/13:$LIBRARY_PATH
+export CPATH=/opt/rh/gcc-toolset-13/root/usr/include:$CPATH
+
+yum install -y git make wget openssl-devel bzip2-devel libffi-devel zlib-devel cmake
+
+echo "-------------------Installing llvmlite----------------------"
+
+LLVM_PROJECT_GIT_URL="https://github.com/llvm/llvm-project.git"
+LLVM_PROJECT_GIT_TAG="llvmorg-20.1.8"
+
+LLVMLITE_PACKAGE_URL="https://github.com/numba/llvmlite"
+LLVMLITE_VERSION="v0.46.0dev0"
+
+LLVM_SRC_DIR=$WORKING_DIR/llvm-project
+LLVM_INSTALL_DIR=$WORKING_DIR/llvm-install
+
+git clone -b ${LLVM_PROJECT_GIT_TAG} ${LLVM_PROJECT_GIT_URL}
+git clone -b ${LLVMLITE_VERSION} ${LLVMLITE_PACKAGE_URL}
+
+python3.12 -m pip install ninja
+
+cd $LLVM_SRC_DIR
+git fetch --all --tags
+git checkout $LLVM_PROJECT_GIT_TAG
+
+# Build & install LLVM
+cmake -S llvm -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_DIR \
+  -DLLVM_ENABLE_PROJECTS="clang;lld" \
+  -DLLVM_TARGETS_TO_BUILD="PowerPC"   
+
+cmake --build build --target install -j$(nproc)
+
+cd $WORKING_DIR/llvmlite
+# Build & install llvmlite
+export CMAKE_PREFIX_PATH=$LLVM_INSTALL_DIR/lib/cmake/llvm
+export CXXFLAGS="-fPIC"
+python3.12 -m pip install .
+
+echo "-------------------successfully Installed llvmlite----------------------"
+
+
+echo "---------------------------------Installing openblas from source----------------"
+git clone https://github.com/OpenMathLib/OpenBLAS
+cd OpenBLAS
+git checkout v0.3.29
+git submodule update --init
+
+PREFIX=local/openblas
+
+# Set build options
+declare -a build_opts
+# Fix ctest not automatically discovering tests
+LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
+export CF="${CFLAGS} -Wno-unused-parameter -Wno-old-style-declaration"
+unset CFLAGS
+export USE_OPENMP=1
+build_opts+=(USE_OPENMP=${USE_OPENMP})
+export PREFIX=${PREFIX}
+
+# Handle Fortran flags
+if [ ! -z "$FFLAGS" ]; then
+    export FFLAGS="${FFLAGS/-fopenmp/ }"
+    export FFLAGS="${FFLAGS} -frecursive"
+    export LAPACK_FFLAGS="${FFLAGS}"
+fi
+export PLATFORM=$(uname -m)
+build_opts+=(BINARY="64")
+build_opts+=(DYNAMIC_ARCH=1)
+build_opts+=(TARGET="POWER9")
+BUILD_BFLOAT16=1
+
+# Placeholder for future builds that may include ILP64 variants.
+build_opts+=(INTERFACE64=0)
+build_opts+=(SYMBOLSUFFIX="")
+
+# Build LAPACK
+build_opts+=(NO_LAPACK=0)
+
+# Enable threading and set the number of threads
+build_opts+=(USE_THREAD=1)
+build_opts+=(NUM_THREADS=8)
+
+# Disable CPU/memory affinity handling to avoid problems with NumPy and R
+build_opts+=(NO_AFFINITY=1)
+
+# Build OpenBLAS
+make -j8 ${build_opts[@]} CFLAGS="${CF}" FFLAGS="${FFLAGS}" prefix=${PREFIX}
+
+# Install OpenBLAS
+CFLAGS="${CF}" FFLAGS="${FFLAGS}" make install PREFIX="${PREFIX}" ${build_opts[@]}
+OpenBLASInstallPATH=$(pwd)/$PREFIX
+OpenBLASConfigFile=$(find . -name OpenBLASConfig.cmake)
+OpenBLASPCFile=$(find . -name openblas.pc)
+sed -i "/OpenBLAS_INCLUDE_DIRS/c\SET(OpenBLAS_INCLUDE_DIRS ${OpenBLASInstallPATH}/include)" ${OpenBLASConfigFile}
+sed -i "/OpenBLAS_LIBRARIES/c\SET(OpenBLAS_INCLUDE_DIRS ${OpenBLASInstallPATH}/include)" ${OpenBLASConfigFile}
+sed -i "s|libdir=local/openblas/lib|libdir=${OpenBLASInstallPATH}/lib|" ${OpenBLASPCFile}
+sed -i "s|includedir=local/openblas/include|includedir=${OpenBLASInstallPATH}/include|" ${OpenBLASPCFile}
+export LD_LIBRARY_PATH="$OpenBLASInstallPATH/lib"
+export PKG_CONFIG_PATH="$OpenBLASInstallPATH/lib/pkgconfig:${PKG_CONFIG_PATH}"
+cd ..
+echo "------------openblas installed--------------------"
+
+python3.12 -m pip install numpy==2.0.2 setuptools
+
+#clone repository
+git clone $PACKAGE_URL
+cd  $PACKAGE_DIR
+git checkout $PACKAGE_VERSION
+
+
+
+# echo "before CXXFLAGS............$CXXFLAGS........."
+export CXXFLAGS=-I/usr/include
+# echo "after CXXFLAGS............$CXXFLAGS........."
+
+PYTHON_VERSION=$(python3.12 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+#install
+if ! python3.12 -m pip install . ; then
+    echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+    exit 1
+fi
+
+#test
+cd $WORKING_DIR
+if ! python3.12 -c "import numba; import numba.core.annotations; import numba.core.datamodel; import numba.core.rewrites; import numba.core.runtime; import numba.core.typing; import numba.core.unsafe; import numba.experimental.jitclass; import numba.np.ufunc; import numba.pycc; import numba.scripts; import numba.testing; import numba.tests; import numba.tests.npyufunc;"; then
+    echo "--------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
+    exit 2
+else
+    echo "------------------$PACKAGE_NAME:Install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
+fi
+


### PR DESCRIPTION
Updated build script on numba to build latest version. 
Ref Doc:  https://github.com/numba/numba/blob/7484a86bd9ce4d7dbc386da887f62a7bd54be597/setup.py#L27
Also llvmlite==v0.46.0dev0 requires minimum version of llvm-project==v20.* 