### PR TITLE
Fix build script mapping for latest version i.e. 0.14.6

### DIFF
--- a/s/statsmodels/build_info.json
+++ b/s/statsmodels/build_info.json
@@ -1,22 +1,22 @@
 {
-    "maintainer": "kiranNukal",
+    "maintainer": "Shivansh-ibm",
     "package_name": "statsmodels",
     "github_url": "https://github.com/statsmodels/statsmodels.git",
-    "version": "v0.14.0",
+    "version": "v0.14.6",
     "wheel_build" : true,
     "default_branch": "main",
     "package_dir": "s/statsmodels",
-    "build_script": "statsmodels_0.14.0_ubi_9.3.sh",
+    "build_script": "statsmodels_0.14.6_ubi_9.3.sh",
     "docker_build": false,
     "validate_build_script": true,
     "use_non_root_user": false,
     "v0.13.5": {
       "build_script": "statsmodels_ubi_9.3.sh"
     },
-    "v0.14.4": {
-      "build_script": "statsmodels_0.14.4_ubi_9.3.sh"
+    "v0.14.0": {
+      "build_script": "statsmodels_0.14.0_ubi_9.3.sh"
     },
     "*": {
-      "build_script": "statsmodels_0.14.0_ubi_9.3.sh"
+      "build_script": "statsmodels_0.14.6_ubi_9.3.sh"
     }
   }

--- a/s/statsmodels/statsmodels_0.14.6_ubi_9.3.sh
+++ b/s/statsmodels/statsmodels_0.14.6_ubi_9.3.sh
@@ -2,13 +2,13 @@
 # -----------------------------------------------------------------------------
 #
 # Package          : statsmodels
-# Version          : 0.14.4
+# Version          : 0.14.6
 # Source repo      : https://github.com/statsmodels/statsmodels.git
 # Tested on        : UBI:9.3
 # Language         : Python
 # Ci-Check     : True
 # Script License   : Apache License, Version 2 or later
-# Maintainer       : Sai Kiran Nukala <sai.kiran.nukala@ibm.com>
+# Maintainer       : Shivansh sharma <shivansh.s1@ibm.com>
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.
@@ -19,7 +19,7 @@
 # -----------------------------------------------------------------------------
 echo "------------------------------------------------------------Cloning statsmodels github repo--------------------------------------------------------------"
 PACKAGE_NAME=statsmodels
-PACKAGE_VERSION=${1:-v0.14.4}
+PACKAGE_VERSION=${1:-v0.14.6}
 PACKAGE_URL=https://github.com/statsmodels/statsmodels.git
 PACKAGE_DIR=statsmodels
 
@@ -43,7 +43,7 @@ fi
 
 python3.12 -m pip install pytest
 if [ "$(python3.12 --version | grep "3.12")" ]; then
-  python3.12 -m pip install numpy==2.2.2
+  python3.12 -m pip install numpy==2.0.2
   python3.12 -m pip install pandas==2.2.3
   python3.12 -m pip install scipy==1.15.2 --prefer-binary
 fi


### PR DESCRIPTION
Updated build_info to map correct build script against latest version. Also pinned the numpy version to build wheel against the correct numpy version used in runtime