### PR TITLE
OSE: fixed 403 forbidden error for qhull and added dependencies and updated matplotlib_ubi_9.3.sh

### DIFF
--- a/m/matplotlib/matplotlib_ubi_9.3.sh
+++ b/m/matplotlib/matplotlib_ubi_9.3.sh
@@ -64,6 +64,7 @@ python3.12 -c "import matplotlib; print(matplotlib.__file__)"
 python3.12 -m pip install  "pyparsing<3.2"  "patchelf>=0.11.0" "setuptools_scm>=7" 'meson-python<0.17.0,>=0.13.1'
 pytest ./lib/matplotlib/tests/test_units.py
 
+
 if [ $? == 0 ]; then
      echo "------------------$PACKAGE_NAME::Test_Pass---------------------"
      echo "$PACKAGE_VERSION $PACKAGE_NAME"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
