### PR TITLE
Fixing build script

### DIFF
--- a/p/pymssql/build_info.json
+++ b/p/pymssql/build_info.json
@@ -1,12 +1,12 @@
 {
-  "maintainer": "SakshiJain0302",
+  "maintainer": "Shivansh-ibm",
   "package_name": "pymssql",
   "github_url": "https://github.com/pymssql/pymssql.git",
-  "version": "v2.3.8",
+  "version": "v2.3.11",
   "wheel_build" : true,
   "package_dir": "p/pymssql",
   "default_branch": "master",
-  "build_script": "pymssql_2.3.8_ubi_9.6.sh",
+  "build_script": "pymssql_2.3.11_ubi_9.6.sh",
   "docker_build": false,
   "validate_build_script": true,
   "use_non_root_user": "false",
@@ -17,6 +17,6 @@
     "build_script":"pymssql_2.3.2_ubi_9.3.sh"
   },
   "*":{
-    "build_script":"pymssql_2.3.8_ubi_9.6.sh"
+    "build_script":"pymssql_2.3.11_ubi_9.6.sh"
   }
 }

--- a/p/pymssql/pymssql_2.3.11_ubi_9.6.sh
+++ b/p/pymssql/pymssql_2.3.11_ubi_9.6.sh
@@ -2,13 +2,13 @@
 # ----------------------------------------------------------------------------
 #
 # Package       : pymssql
-# Version       : v2.3.8
+# Version       : v2.3.11
 # Source repo   : https://github.com/pymssql/pymssql.git
 # Tested on     : UBI:9.6
 # Language      : Python
 # Ci-Check      : True
 # Script License: Apache License, Version 2 or later
-# Maintainer    : Aastha Sharma <Aastha.Sharma4@ibm.com>
+# Maintainer    : Shivansh Sharma <Shivansh.s1@ibm.com>
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.
@@ -20,7 +20,7 @@
 
 #variables
 PACKAGE_NAME=pymssql
-PACKAGE_VERSION=${1:-v2.3.8}
+PACKAGE_VERSION=${1:-v2.3.11}
 PACKAGE_URL=https://github.com/pymssql/pymssql.git
 PACKAGE_DIR=pymssql
 CURRENT_DIR=`pwd`
@@ -54,7 +54,7 @@ if [[ "$(printf '%s\n' "2.3.4" "${PACKAGE_VERSION#v}" | sort -V | head -n1)" == 
         sed -i 's/(int, long, decimal.Decimal)/(int, decimal.Decimal)/' src/pymssql/_mssql.pyx
 fi
 sed -i "s/{TDS_ENCRYPTION_LEVEL.keys())}/{list(TDS_ENCRYPTION_LEVEL.keys())}/" src/pymssql/_mssql.pyx
-export SETUPTOOLS_SCM_PRETEND_VERSION=2.3.8
+export SETUPTOOLS_SCM_PRETEND_VERSION=${PACKAGE_VERSION#v}
 BUILD_CMD="python3.12 dev/build.py \
     --ws-dir=./freetds \
     --dist-dir=./dist \


### PR DESCRIPTION
Since sETUPTOOLS_SCM_PRETEND_VERSION is hardcoded to 2.3.8. So, even though the build script runs correctly, it is building wheel for 2.3.8 version . So, fixing it 