### PR TITLE
fix: Failing test_memleaks test due to import since 7.2.0

### DIFF
--- a/p/psutil/psutil_7.0.0_ubi_9.3.sh
+++ b/p/psutil/psutil_7.0.0_ubi_9.3.sh
@@ -32,7 +32,7 @@ cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 
 # Install additional dependencies
-python3.12 -m pip install setuptools wheel pytest overlay pytest-instafail pytest-xdist
+python3.12 -m pip install setuptools wheel pytest overlay pytest-instafail pytest-xdist psleak
 
 #install
 if ! python3.12 -m pip install -e . ; then


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
