### PR TITLE
OSE: Conditional numpy installation based on Python version

### DIFF
--- a/p/pandas/pandas_1.5.3_ubi_9.3.sh
+++ b/p/pandas/pandas_1.5.3_ubi_9.3.sh
@@ -43,7 +43,18 @@ pip3 install pytest hypothesis build meson meson-python
 pip3 install cython==0.29.32
 pip3 install --upgrade --force-reinstall setuptools
 pip3 install --upgrade six
-pip3 install numpy==1.23.5
+
+PYVER=$(python3 - <<EOF
+import sys
+print(f"{sys.version_info.major}.{sys.version_info.minor}")
+EOF
+)
+
+if [[ "$PYVER" == "3.12" ]]; then
+    pip3 install numpy==1.26.4
+else
+    pip3 install numpy==1.23.5
+fi
 
 # Attempt to install
 if ! (pip3 install .) ; then


### PR DESCRIPTION
Install numpy version based on Python version.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
