### PR TITLE
OSE: Updated CatBoost and LLVM installation and corrected paths in orange3_3.38.1_ubi_9.3.sh

### DIFF
--- a/o/orange3/orange3_3.38.1_ubi_9.3.sh
+++ b/o/orange3/orange3_3.38.1_ubi_9.3.sh
@@ -35,7 +35,7 @@ yum install -y \
  gcc-toolset-13 gcc-toolset-13-gcc-c++ gcc-toolset-13-gcc-gfortran \
  gcc-toolset-13-binutils-devel libstdc++-devel \
  openssl-devel zlib-devel bzip2 xz-devel sqlite-devel \
- libjpeg-devel rust cargo lld
+ libjpeg-devel rust cargo lld xz
 
 export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
 export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:$LD_LIBRARY_PATH
@@ -82,7 +82,7 @@ echo "------------------ Clang 17 ------------------"
 CLANG_VERSION=17.0.6
 LLVM_TARBALL="clang+llvm-${CLANG_VERSION}-powerpc64le-linux-rhel-8.8.tar.xz"
 curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/${LLVM_TARBALL}
-tar -xf ${LLVM_TARBALL}
+tar -xvf ${LLVM_TARBALL}
 LLVM_DIR="clang+llvm-${CLANG_VERSION}-powerpc64le-linux-rhel-8.8"
 
 export PATH=$CURRENT_DIR/${LLVM_DIR}/bin:$PATH


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
