### PR TITLE
OSE: Ensure CMake uses active Python interpreter and fix NumPy detection in pyarrow_15.0.1_ubi_9.3.sh

### DIFF
--- a/p/pyarrow/pyarrow_15.0.1_ubi_9.3.sh
+++ b/p/pyarrow/pyarrow_15.0.1_ubi_9.3.sh
@@ -112,7 +112,7 @@ export PYARROW_BUNDLE_ARROW_CPP_HEADERS=1
 
 version=$(echo "$PACKAGE_VERSION" | sed 's/^apache-arrow-//')
 export SETUPTOOLS_SCM_PRETEND_VERSION=$version
-export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${ARROW_HOME}/lib64:${LD_LIBRARY_PATH}
 if ! python3 setup.py bdist_wheel --dist-dir="$CURRENT_DIR/" ; then
         echo "------------------$PACKAGE_NAME:wheel_built_fails---------------------"
         echo "$PACKAGE_VERSION $PACKAGE_NAME"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
