### PR TITLE
OSE: Fix Boost build failure by ensuring valid CPU_COUNT for b2 -j option in Update pyarrow_ubi_9.3.sh

### DIFF
--- a/p/pyarrow/pyarrow_ubi_9.3.sh
+++ b/p/pyarrow/pyarrow_ubi_9.3.sh
@@ -28,7 +28,6 @@ CURRENT_DIR="${PWD}"
 yum install -y git wget gcc gcc-c++ python python3-devel python3 python3-pip openssl-devel cmake
 
 echo "Dependencies installed."
-
 mkdir dist
 export CXX=g++
 export CC=gcc


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
