### PR TITLE
Fix GHA failure for ollama

### DIFF
--- a/o/ollama/ollama_v0.13.1_ubi_9.6.sh
+++ b/o/ollama/ollama_v0.13.1_ubi_9.6.sh
@@ -70,10 +70,14 @@ git clone $PACKAGE_URL
 cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 
-echo "** Applying Power10 Patches..."
-patch -p1 < ${SCRIPT_PATH}/build_power_${PACKAGE_VERSION}.patch
-patch -p1 < ${SCRIPT_PATH}/set_threads_env_${PACKAGE_VERSION}.patch
-patch -p1 < ${SCRIPT_PATH}/enable_mma_${PACKAGE_VERSION}.patch
+echo "** Downloading and Applying Power10 Patches..."
+wget -O build_power.patch https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/o/ollama/build_power_v0.13.1.patch
+wget -O set_threads_env.patch https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/o/ollama/set_threads_env_v0.13.1.patch
+wget -O enable_mma.patch https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/o/ollama/enable_mma_v0.13.1.patch
+
+patch -p1 < build_power.patch
+patch -p1 < set_threads_env.patch
+patch -p1 < enable_mma.patch
 
 # -----------------------------------------------------------------------------
 # Build Ollama


### PR DESCRIPTION
The build-script is executed as a single file without patch file in a CI pipeline. So, downloading the patches directly from build script repo  and applying to fix patch not found failure errors

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
