### PR TITLE
anltr-runtime-python3-fix

### DIFF
--- a/a/antlr4-python3-runtime/antlr4-python3-runtime_ubi_9.6.sh
+++ b/a/antlr4-python3-runtime/antlr4-python3-runtime_ubi_9.6.sh
@@ -21,7 +21,7 @@
 set -e
 
 # Variables
-PACKAGE_DIR="antlr4"
+PACKAGE_DIR="antlr4/runtime/Python3"
 PACKAGE_NAME="antlr4-python3-runtime"
 PACKAGE_VERSION="${1:-4.9.3}"
 PACKAGE_URL="https://github.com/antlr/antlr4.git"
@@ -85,6 +85,8 @@ fi
 
 test_status=1  # 0 = success, non-zero = failure
 
+# Temporary fix for Python 3.12+ compatibility
+sed -i 's/assertEquals/assertEqual/g' ./runtime/Python3/tests/TestIntervalSet.py
 # Run tests if any matching test files found
 if ls ./runtime/Python3/tests/*.py > /dev/null 2>&1 && [ $test_status -ne 0 ]; then
     echo "Running tests..."


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

This PR fixes failure in building wheel for antlr-runtime-python3. 
GHA Logs ->  https://github.com/ppc64le/build-scripts/actions/runs/21429708723/job/61706217737

This sets the package directory for building antlr-runtime-python3 wheel to https://github.com/antlr/antlr4/tree/master/runtime/Python3 

The behaviour remains unchanged if `PACKAGE_WHEEL_SUBPATH`  is not set. 

Would help building packages where pyproject.toml or setup.py in not present in parent directory of a package repository. 