### PR TITLE
Use lower version scripts ie 2.0.1 and 2.1.0  for pytorch 2.0.0 and 2…

### DIFF
--- a/p/pytorch/build_info.json
+++ b/p/pytorch/build_info.json
@@ -42,5 +42,5 @@
   },
   "v2.1.2":{
     "build_script":"pytorch_2.1.0_ubi_9.3.sh"
-  },
+  }
 }


### PR DESCRIPTION
….1.2 as defaults script ie 2.6.0 builds scipy 1.15.2 incompatible with python 3.9

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
