### PR TITLE
OSE: Fix Python version parsing to avoid truncating 3.11 to 3.1 in onnxruntime_1.22.0_ubi_9.3.sh

### DIFF
--- a/o/onnxruntime/onnxruntime_1.22.0_ubi_9.3.sh
+++ b/o/onnxruntime/onnxruntime_1.22.0_ubi_9.3.sh
@@ -27,7 +27,7 @@ CURRENT_DIR=$(pwd)
 
 echo "Installing dependencies..."
 yum install -y git make libtool wget gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-gcc-gfortran libevent-devel zlib-devel openssl-devel clang python3.11 python3.11-devel python3.11-pip cmake xz bzip2-devel libffi-devel patch ninja-build
-PYTHON_VERSION=$(python3.11 --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+PYTHON_VERSION=$(python3.11 --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1-2)
 source /opt/rh/gcc-toolset-13/enable
 
 export CC=gcc


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
