### PR TITLE
OSE: Fix ORC dependency failure and brotli auditwheel repair issue

### DIFF
--- a/p/pyarrow/pyarrow_ubi_9.3.sh
+++ b/p/pyarrow/pyarrow_ubi_9.3.sh
@@ -25,7 +25,8 @@ PACKAGE_URL=https://github.com/apache/arrow.git
 PACKAGE_DIR=./arrow/python
 CURRENT_DIR="${PWD}"
 
-yum install -y git wget gcc gcc-c++ python python3-devel python3 python3-pip openssl-devel cmake
+yum install -y git wget gcc gcc-c++ python python3-devel python3 python3-pip openssl-devel cmake brotli brotli-devel
+
 
 echo "Dependencies installed."
 mkdir dist


### PR DESCRIPTION
- Disabled ARROW_ORC to resolve CMake configuration failure caused by missing ORC library.
- Added LD_LIBRARY_PATH export for /usr/local/lib64 to allow auditwheel to locate libbrotlicommon.so.1 during wheel repair.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
