### PR TITLE
fix: pip location failure for py other than 3.12

### DIFF
--- a/t/tree-sitter/tree-sitter_ubi_9.6.sh
+++ b/t/tree-sitter/tree-sitter_ubi_9.6.sh
@@ -96,35 +96,35 @@ TREE_SITTER_RUST_VERSION=$(get_pkg_version tree-sitter-rust)
 git clone https://github.com/tree-sitter/tree-sitter-html.git
 cd tree-sitter-html
 git checkout v$TREE_SITTER_HTML_VERSION
-pip3.12 install .
+python3.12 -m pip install .
 cd $BUILD_HOME
 
 # Build and Install tree-sitter-json
 git clone https://github.com/tree-sitter/tree-sitter-json.git
 cd tree-sitter-json
 git checkout v$TREE_SITTER_JSON_VERSION
-pip3.12 install .
+python3.12 -m pip install .
 cd $BUILD_HOME
 
 # Build and Install tree-sitter-python
 git clone https://github.com/tree-sitter/tree-sitter-python.git
 cd tree-sitter-python
 git checkout v$TREE_SITTER_PYTHON_VERSION
-pip3.12 install .
+python3.12 -m pip install .
 cd $BUILD_HOME
 
 # Build and Install tree-sitter-javascript
 git clone https://github.com/tree-sitter/tree-sitter-javascript.git
 cd tree-sitter-javascript
 git checkout v$TREE_SITTER_JAVASCRIPT_VERSION
-pip3.12 install .
+python3.12 -m pip install .
 cd $BUILD_HOME
 
 # Build and Install tree-sitter-rust
 git clone https://github.com/tree-sitter/tree-sitter-rust.git
 cd tree-sitter-rust
 git checkout v$TREE_SITTER_RUST_VERSION
-pip3.12 install .
+python3.12 -m pip install .
 cd $BUILD_HOME
 
 cd "$PACKAGE_DIR"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
