### PR TITLE
feat(CI): Add support for large runners

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       large-runner:
-        description: "New Runner to use for failing build"
+        description: "New runner to use for failing build"
         required: true
         default: "ubuntu-24.04-ppc64le-2xlarge-p10"
         type: choice
@@ -22,8 +22,8 @@ on:
 
 run-name: >
   ${{ github.event_name == 'workflow_dispatch'
-      && format('PR build for {0} on {1}', inputs.pr_number, inputs.large-runner)
-      || format('PR build #{0}', github.event.pull_request.number) }}
+      && format('Retriggered build on {0} for PR {1}', inputs.large-runner, inputs.pr_number)
+      || github.event.pull_request.title }}
 
 jobs:
   validate:
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install required packages
         run: |


### PR DESCRIPTION
As of today, builds which fail due to resource-exhaustion (exit code 137) or other failures which result from 'Self-hosted runner lost communication' errors have no way to re-run builds on larger runners for IBM Power and IBM Z. This PR provides the maintainers a way to re-run the failing PR to make sure resource is not the blocker.

This PR is mainly for [PR Builds](https://github.com/ppc64le/build-scripts/blob/master/.github/workflows/pr-build.yaml). Another PR will be sent for Currency Builds. 