### PR TITLE
Fix setuptools related build issue in opencv-python script

### DIFF
--- a/o/opencv-python/opencv-python_ubi_9.3.sh
+++ b/o/opencv-python/opencv-python_ubi_9.3.sh
@@ -138,8 +138,7 @@ git apply set_cpp_to_17_v4.25.3.patch
 
 #installing protobuf
 cd python
-#python setup.py install --cpp_implementation
-python -m pip install . --no-build-isolation --config-settings="--build-option=--cpp_implementation"
+python -m pip install . --no-build-isolation 
 echo "-----------------------------------------------------Installed protobuf-----------------------------------------------------"
 
 


### PR DESCRIPTION
Downgraded setuptools to version to 79.0.1  as it has pkg_resource module to fix protobuf build issue in opencv-python script for python version 3.13 


The above change fixes the following error:- 
```
   import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
