### PR TITLE
[ODH]  Fix and Updated the grpcio v1.62.3 build script to improve version compatibility

### DIFF
--- a/g/grpcio/grpcio_1.76.0_ubi_9.6.sh
+++ b/g/grpcio/grpcio_1.76.0_ubi_9.6.sh
@@ -38,7 +38,7 @@ export PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 
 pip3 install -r requirements.txt
 
-[[ "$(echo -e "$PACKAGE_VERSION\nv1.62.3" | sort -V | head -n1)" == "$PACKAGE_VERSION" ]] && pip3 install --force-reinstall Cython==0.29.37
+[[ "$(printf "%s\n" "$PACKAGE_VERSION" v1.62.3 | sort -V | head -n1)" == "$PACKAGE_VERSION" ]] && pip3 install --force-reinstall Cython==0.29.37
 
 # Install the package
 pip3 install . --no-build-isolation


### PR DESCRIPTION
avoid hardcoding specific versions
The requirements.txt taken directly from the upstream gRPC repository to address version compatibility issues and align with official build dependencies.

build :

```
Collecting cython<3.0.0rc1,>=0.29.8 (from -r requirements.txt (line 3))
  Downloading Cython-3.0.0b3-py2.py3-none-any.whl.metadata (3.1 kB)
Collecting protobuf<5.0dev,>=4.21.3 (from -r requirements.txt (line 4))
  Downloading protobuf-4.25.8-py3-none-any.whl.metadata (541 bytes)
Requirement already satisfied: wheel>=0.29 in /build-scripts/script/pyvenv_3.11/lib64/python3.11/site-packages (from -r requirements.txt (line 5)) (0.46.3)
Requirement already satisfied: packaging>=24.0 in /build-scripts/script/pyvenv_3.11/lib64/python3.11/site-packages (from wheel>=0.29->-r requirements.txt (line 5)) (26.0)
Downloading Cython-3.0.0b3-py2.py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 25.9 MB/s  0:00:00
Downloading protobuf-4.25.8-py3-none-any.whl (156 kB)
Downloading coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl (256 kB)
Installing collected packages: protobuf, cython, coverage
Successfully installed coverage-7.13.4 cython-3.0.0b3 protobuf-4.25.8
Collecting Cython==0.29.37
  Downloading Cython-0.29.37-py2.py3-none-any.whl.metadata (3.1 kB)
Downloading Cython-0.29.37-py2.py3-none-any.whl (989 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 989.5/989.5 kB 32.1 MB/s  0:00:00
Installing collected packages: Cython
  Attempting uninstall: Cython
    Found existing installation: Cython 3.0.0b3
    Uninstalling Cython-3.0.0b3:
      Successfully uninstalled Cython-3.0.0b3
Successfully installed Cython-0.29.37
Processing ./.
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: grpcio
  Building wheel for grpcio (pyproject.toml) ... /done
  Created wheel for grpcio: filename=grpcio-1.62.3-cp311-cp311-linux_ppc64le.whl size=100248880 sha256=b75c9a7b9c1b5ebae74c71ba65aa2b492feab13c384ebbb638f99fc8d4ee973d
  Stored in directory: /tmp/pip-ephem-wheel-cache-i8ehdout/wheels/58/ef/89/c604613949e070be62b2bda8beab736ca64d5427ae49a55cfc
Successfully built grpcio
Installing collected packages: grpcio
Successfully installed grpcio-1.62.3
------------------grpc::Build_Pass---------------------
v1.62.3 grpc
grpc  | https://github.com/grpc/grpc.git | v1.62.3  | Pass |  Build_Success
All modules imported successfully
------------------grpc::Test_Pass---------------------
v1.62.3 grpc
grpc  | https://github.com/grpc/grpc.git | v1.62.3  | Pass |  Test_Success

```