### PR TITLE
Updated script for array_record v0.5.0

### DIFF
--- a/a/array_record/array_record_ubi_9.3.sh
+++ b/a/array_record/array_record_ubi_9.3.sh
@@ -29,8 +29,8 @@ export CURRENT_DIR=${PWD}
 
 echo "Installing dependencies..."
 
-#export PYTHON_BIN="$VENV_DIR/bin/python"
-#export PATH="$VENV_DIR/bin:$PATH"
+export PYTHON_BIN="$VENV_DIR/bin/python"
+export PATH="$VENV_DIR/bin:$PATH"
 
 
 yum install -y git make cmake zip tar wget python3.12 python3.12-devel python3.12-pip python3-devel java-11-openjdk java-11-openjdk-devel java-11-openjdk-headless zlib-devel libjpeg-devel openssl openssl-devel freetype-devel pkgconfig rsync


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

- Specified bazel version, python version and PYTHON_BIN path in script
- Installed required dependencies for `bazel==5.4.0` 
- Using gcc11 as it required to build `bazel 5.4.0`
- Built and installed `bazel 5.4.0` 
- Triggered `oss/build_whl` script from `array_record` repo, it will build wheel and also executes tests. 
