### PR TITLE
feat(CI): add large runner support for currency workflows

### DIFF
--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -41,7 +41,22 @@ on:
         required: false
         default: 'None'
 
-run-name: Currency Build ${{ inputs.package_name }} && Unique ID ${{ inputs.unique_id }}
+      ## for builds which fail on default runner  
+      large-runner-label:
+        description: "New runner to use for failing build"
+        required: false
+        type: choice
+        options:
+          - ''
+          - ubuntu-24.04-ppc64le-2xlarge-p10
+          - ubuntu-24.04-ppc64le-4xlarge-p10
+
+run-name: >
+  ${{ inputs.large-runner-label != '' &&
+      format('Retriggered Currency Build for package {0} and Unique ID {1} on {2}', inputs.package_name, inputs.unique_id, inputs.large-runner-label) ||
+      format('Currency Build {0} && Unique ID {1}', inputs.package_name, inputs.unique_id)
+  }}
+
 
 jobs:
   build_info:
@@ -109,7 +124,7 @@ jobs:
   build:
     needs: build_info
     if: ${{ inputs.validate_build_script == 'true' }}
-    runs-on: ubuntu-24.04-ppc64le-p10
+    runs-on: ${{ inputs.large-runner-label != '' && inputs.large-runner-label || 'ubuntu-24.04-ppc64le-p10' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -174,7 +189,7 @@ jobs:
     needs: build_info
     name: Create Wheel for Python ${{ matrix.python-version }}
     if: ${{ inputs.wheel_build == 'true' }}
-    runs-on: ubuntu-24.04-ppc64le-p10
+    runs-on: ${{ inputs.large-runner-label != '' && inputs.large-runner-label || 'ubuntu-24.04-ppc64le-p10' }}
     strategy:
       fail-fast: false
       matrix:
@@ -408,7 +423,7 @@ jobs:
   build_docker:
     needs: build_info 
     if: ${{ inputs.build_docker == 'true' }}
-    runs-on: ubuntu-24.04-ppc64le-p10
+    runs-on: ${{ inputs.large-runner-label != '' && inputs.large-runner-label || 'ubuntu-24.04-ppc64le-p10' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR builds on #7926 by allowing `currency-build.yml` to also use larger runners. 

By default, if the `large-runner-label` field is empty, the build will default to the `ubuntu-24.04-ppc64le-p10` runner. 
Incase the build fails with the default runner, maintainers now will be able to trigger another build, this time with a larger runner. 

For builds which are rerun on a larger runner, the Workflow Run will contain the appropriate title.

When triggered normally:
<img width="367" height="26" alt="image" src="https://github.com/user-attachments/assets/a57ab07b-6066-4f70-9b5c-f29a50e3271f" />

When re-triggered on large runner
<img width="887" height="25" alt="image" src="https://github.com/user-attachments/assets/2100f0b9-c44c-429e-9353-37f1df3955a1" />
