### PR TITLE
OSE: Fix auditwheel repair failure by ensuring libggml-cpu-power10.so is discoverable in ollama_v0.12.10_ubi_9.6.sh

### DIFF
--- a/o/ollama/ollama_v0.12.10_ubi_9.6.sh
+++ b/o/ollama/ollama_v0.12.10_ubi_9.6.sh
@@ -81,6 +81,7 @@ echo "**** Building Ollama with CMake..."
 cmake -B build
 cmake --build build -j$(nproc)
 
+export LD_LIBRARY_PATH=$(pwd)/build/lib/ollama:$LD_LIBRARY_PATH
 export CGO_LDFLAGS="-L$(pwd)/build/lib/ollama/ -lggml-cpu-power10"
 
 echo "**** Building Ollama binary with Go..."


### PR DESCRIPTION
Exported LD_LIBRARY_PATH to include build/lib/ollama before running auditwheel so libggml-cpu-power10.so is discoverable during the repair phase.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
