### PR TITLE
Update tensorflow build script for ppc64le exclusion

### DIFF
--- a/t/tensorflow/tensorflow_2.14.1_ubi9.3.sh
+++ b/t/tensorflow/tensorflow_2.14.1_ubi9.3.sh
@@ -270,11 +270,15 @@ wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/t
 git apply tf_2.14.1_fix.patch
 echo "------------Applied patch successfully---------------------"
 
+sed -i "/python_aarch64/ s|! -path '\*python_aarch64\*'|! -path '*python_aarch64*' \\\
+  ! -path '*python_ppc64le*'|" tensorflow/tools/pip_package/build_pip_package.sh
+echo "------------Added ppc64le tag to exclude external paths---------------------"
+
+
 yes n | ./configure
 
 echo "------------------------Bazel query-------------------"
 bazel query "//tensorflow/tools/pip_package:*"
-
 
 #Install
 if ! (bazel build -s --distdir=/bazel-dist //tensorflow/tools/pip_package:build_pip_package --config=opt --define=llvm_enable_pdb=false) ; then  


### PR DESCRIPTION
Modified build script to exclude specific Python paths for ppc64le architecture.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
