### PR TITLE
fix: dynamic linking to resolve auditwheel libc detection failure, set compile flags and modifed pip install command

### DIFF
--- a/t/tree_sitter_c/tree_sitter_c_ubi_9.6.sh
+++ b/t/tree_sitter_c/tree_sitter_c_ubi_9.6.sh
@@ -90,7 +90,6 @@ export CFLAGS="-O2 -fPIC -fno-lto"
 #dynamic libc dependency so auditwheel can detect glibc
 export LDFLAGS="-Wl,-Bdynamic -Wl,--no-as-needed -lc"
 
-# 4) Build a wheel without isolation so these flags are honored
 # Install the package
 if ! python3 -m pip install .; then
     echo "------------------$PACKAGE_NAME:install_fails------------------------"


### PR DESCRIPTION
The build process for the tree-sitter-c Python extension was producing a static-linked artifact, which prevented auditwheel from detecting the appropriate libc and caused wheel repair to fail. The build has now been updated to ensure the extension is generated as a dynamically linked shared object. This restores compatibility with auditwheel and enables successful internal wheel generation.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
