### PR TITLE
[ODH] Fix DuckDB test script to use dynamic version

### DIFF
--- a/d/duckdb/duckdb_ubi_9.6.sh
+++ b/d/duckdb/duckdb_ubi_9.6.sh
@@ -73,10 +73,10 @@ assert con.execute("select 42").fetchall() == [(42,)]
 
 # 2 Version check (SQL side)
 version_sql = con.execute("select version()").fetchone()[0]
-assert version_sql.startswith("v1.4.3")
+assert version_sql.startswith("${PACKAGE_VERSION}")
 
 # 3 Python package version check
-assert duckdb.__version__ == "1.4.3"
+assert duckdb.__version__ == "${PACKAGE_VERSION#v}"
 
 print("All DuckDB runtime tests passed.")
 EOF


### PR DESCRIPTION
build log :

```
[501/501] Linking CXX shared module _duckdb.cpython-311-powerpc64le-linux-gnu.so
*** Installing project into wheel...
-- Install configuration: "Release"
-- Installing: /tmp/tmp7y70wygj/wheel/platlib/_duckdb.cpython-311-powerpc64le-linux-gnu.so
*** Making wheel...
*** Created duckdb-1.4.3-cp311-cp311-linux_ppc64le.whl
Successfully built duckdb-1.4.3-cp311-cp311-linux_ppc64le.whl
Installing duckdb wheel...
Processing ./dist/duckdb-1.4.3-cp311-cp311-linux_ppc64le.whl
Installing collected packages: duckdb
Successfully installed duckdb-1.4.3
All DuckDB runtime tests passed.
------------------duckdb-python: Install & Test Success ------------------
duckdb-python | https://github.com/duckdb/duckdb-python.git | v1.4.3 | GitHub | Pass | Both_Install_and_Test_Success
```