### PR TITLE
Fixed rtree audit wheel skip issue and tox test issue

### DIFF
--- a/r/rtree/rtree_ubi_9.3.sh
+++ b/r/rtree/rtree_ubi_9.3.sh
@@ -48,6 +48,7 @@ then
     cd ../
 fi
 
+
 # Clone or extract the package
 if [[ "$PACKAGE_URL" == *github.com* ]]; then
     if [ -d "$PACKAGE_DIR" ]; then
@@ -59,7 +60,7 @@ if [[ "$PACKAGE_URL" == *github.com* ]]; then
             echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Fail | Clone_Fails"
             exit 1
         fi
-        cd "$PACKAGE_DIR" || exit
+        cd "$PACKAGE_DIR" && mkdir -p lib include || exit
         git checkout "$PACKAGE_VERSION" || exit
     fi
 else
@@ -83,6 +84,19 @@ else
     fi
 fi
 
+# Build spatialindex shared object file . It is part of x86 wheel due to which it is built as an audit wheel
+cd ..
+wget https://github.com/libspatialindex/libspatialindex/releases/download/2.1.0/spatialindex-src-2.1.0.tar.gz
+tar -xvzf spatialindex-src-2.1.0.tar.gz
+cd spatialindex-src-2.1.0
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="../../${PACKAGE_DIR}/${PACKAGE_DIR}" -DCMAKE_INSTALL_LIBDIR=lib
+make -j $(nproc)
+make install
+cd ../../${PACKAGE_DIR}
+
+
+
 # Install the package
 if ! python3 -m pip install ./; then
     echo "------------------$PACKAGE_NAME:install_fails------------------------"
@@ -92,6 +106,11 @@ if ! python3 -m pip install ./; then
 fi
 
 # ------------------ Unified Test Execution Block ------------------
+
+export LD_LIBRARY_PATH=$(pwd)/${PACKAGE_DIR}/lib:$(pwd)/${PACKAGE_DIR}/lib64:$LD_LIBRARY_PATH
+
+# Remove no binary option from tox tests as it forces numpy to install from pypi instead of building from source
+sed -i 's/--only-binary=:all: //; s/{opts} //' tox.ini
 
 test_status=1  # 0 = success, non-zero = failure
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


This PR is to fix audit wheel skip issue for rtree 
rtree has a C component which is called spatialindex, it is built as a shared object file . After building this module audit wheel step runs successfully.

This PR also fixes tox test issues
tox test tries to use numpy from pypi for power which is not present. So changes were made to tox.ini to build numpy from source 