### PR TITLE
Fix build issue on OSE for opencv-python-headless 4.13.0.92

### DIFF
--- a/o/opencv-python-headless/opencv-python-headless_4.13.0.92_ubi_9.5.sh
+++ b/o/opencv-python-headless/opencv-python-headless_4.13.0.92_ubi_9.5.sh
@@ -143,8 +143,8 @@ export C_INCLUDE_PATH=$(python3.12 -c "import numpy; print(numpy.get_include())"
 export CPLUS_INCLUDE_PATH=$C_INCLUDE_PATH
 ln -sf $CURRENT_DIR/$PACKAGE_DIR/tests/SampleVideo_1280x720_1mb.mp4 SampleVideo_1280x720_1mb.mp4
 
-# Build package
-if ! python3.12 -m pip install . ; then
+# Build package (--no-build-isolation ensures numpy C headers are found)
+if ! python3.12 -m pip install . --no-build-isolation ; then
     echo "------------------$PACKAGE_NAME:install_fails-------------------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [NA ] Did you have **Legal approvals** for patch files ? 


This fix is regarding the build failure observed for opencv-headless-python on OSE. 
This change should fix the issue. 