### PR TITLE
Fix imagecodecs build script for latest version i.e. v2026.3.6

### DIFF
--- a/i/imagecodecs/build_info.json
+++ b/i/imagecodecs/build_info.json
@@ -1,11 +1,11 @@
 {
-  "maintainer": "Lenzie.Camilo3",
+  "maintainer": "Shivansh-ibm",
   "package_name": "imagecodecs",
   "github_url": "https://github.com/cgohlke/imagecodecs",
-  "version": "v2025.11.11",
+  "version": "v2026.3.6",
   "wheel_build" : true,
   "default_branch": "master",
-  "build_script": "imagecodecs_v2025.11.11_ubi_9.3.sh",
+  "build_script": "imagecodecs_v2026.3.6_ubi_9.3.sh",
   "package_dir": "i/imagecodecs",
   "docker_build": false,
   "validate_build_script": true,
@@ -14,12 +14,12 @@
     "build_script": "imagecodecs_ubi_9.3.sh"
   },
   "v2025.11.*" : {
-    "build_script": "imagecodecs_v2025.11.11_ubi_9.3.sh"
+    "build_script": "imagecodecs_v2026.3.6_ubi_9.3.sh"
   },
   "v2025.*" : {
     "build_script": "imagecodecs_v2025.8.2_ubi_9.3.sh"
   },
   "*" : {
-    "build_script": "imagecodecs_v2025.11.11_ubi_9.3.sh"
+    "build_script": "imagecodecs_v2026.3.6_ubi_9.3.sh"
   }
 }

--- a/i/imagecodecs/imagecodecs_v2026.3.6_ubi_9.3.sh
+++ b/i/imagecodecs/imagecodecs_v2026.3.6_ubi_9.3.sh
@@ -3,13 +3,13 @@
 # -----------------------------------------------------------------------------
 #
 # Package           : imagecodecs
-# Version           : v2025.11.11
+# Version           : v2026.3.6
 # Source repo       : https://github.com/cgohlke/imagecodecs.git
 # Tested on         : UBI:9.3
 # Language          : C,Python
 # Ci-Check      : True
 # Script License    : Apache License, Version 2.0
-# Maintainer        : Lenzie Camilo <Lenzie.Camilo3@ibm.com>
+# Maintainer        : Shivansh Sharma <shivansh.s1@ibm.com>
 #
 # Disclaimer        : This script has been tested in root mode on given
 # ==========          platform using the mentioned version of the package.
@@ -20,7 +20,7 @@
 # ----------------------------------------------------------------------------
 
 PACKAGE_NAME=imagecodecs
-PACKAGE_VERSION=${1:-v2025.11.11}
+PACKAGE_VERSION=${1:-v2026.3.6}
 PACKAGE_URL=https://github.com/cgohlke/imagecodecs.git
 CURRENT_DIR="${PWD}"
 
@@ -99,7 +99,8 @@ cmake .. && make -j$(nproc) && make install
 cd ../..
 
 # giflib 5.2.2
-wget https://downloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz
+#wget https://downloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz
+wget -O giflib-5.2.2.tar.gz  https://sourceforge.net/projects/giflib/files/giflib-5.x/giflib-5.2.2.tar.gz/download
 tar -xf giflib-5.2.2.tar.gz && cd giflib-5.2.2
 touch doc/giflib-logo.gif
 make -j$(nproc)
@@ -107,9 +108,10 @@ make install
 cd ..
 
 # jxrlib
-git clone https://github.com/MoonchildProductions/jxrlib.git
+#git clone https://github.com/MoonchildProductions/jxrlib.git
+git clone https://github.com/4creators/jxrlib.git
 cd jxrlib && make && make install
-# Set JXR library root path 
+# Set JXR library root path
 JXR_PATH=$(find /usr/lib -type d -name "jxrlib-*" | head -n1)
 # Include dir
 JXR_INC="$JXR_PATH/include"
@@ -215,7 +217,7 @@ cd ..
 
 # libjpeg-turbo 3.1.2
 git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git
-cd libjpeg-turbo 
+cd libjpeg-turbo
 git checkout 3.1.2
 
 # Build 12-bit version
@@ -269,3 +271,4 @@ else
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
     exit 0
 fi
+


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
