### PR TITLE
Ignore py3.9 and py3.13 wheel_build failure

### DIFF
--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -172,6 +172,7 @@ jobs:
     needs: build_info
     if: ${{ inputs.wheel_build == 'true' }}
     runs-on: ubuntu-24.04-ppc64le-p10
+    continue-on-error: true
     env:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       PYTHON_VERSION: "3.9"
@@ -502,6 +503,7 @@ jobs:
    needs: build_info
    if: ${{ inputs.wheel_build == 'true' }}
    runs-on: ubuntu-24.04-ppc64le-p10
+   continue-on-error: true
    env:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       PYTHON_VERSION: "3.13"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
