### PR TITLE
Fix outlines-core wheel version by updating Cargo.toml

### DIFF
--- a/o/outlines-core/outlines-core_ubi_9.3.sh
+++ b/o/outlines-core/outlines-core_ubi_9.3.sh
@@ -757,11 +757,15 @@ python3.12 -m pip install datasets==2.14.7 --no-build-isolation --no-deps
 python3.12 -m pip install "multiprocess==0.70.15"
 python3.12 -m pip install "xxhash==3.4.1"
 python3.12 -m pip install "dill==0.3.7" "fsspec==2023.10.0" aiohttp pyarrow-hotfix
-python3.12 -m pip install "transformers==4.39.2"
+python3.12 -m pip install "transformers==4.39.2" maturin puccinialin
 IBM_WHEELS="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/"
 python3.12 -m pip install   --prefer-binary   --trusted-host wheels.developerfirst.ibm.com   --extra-index-url ${IBM_WHEELS} llvmlite==0.45.1 numba==0.62.1
 
-export SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION
+
+# NOTE: outlines-core is built with maturin (Rust/PyO3).
+# The wheel version comes from Cargo.toml, not setuptools or SCM,
+# so we must update the [package] version here explicitly.
+sed -i "/^\[package\]/,/^\[/{/name = \"outlines-core\"/,/^\[/{s/^version = \".*\"/version = \"${PACKAGE_VERSION}\"/}}" Cargo.toml
 
 #install
 if ! (python3.12 -m pip install -e .) ; then


### PR DESCRIPTION
outlines-core is built using maturin (Rust/PyO3), and the Python wheel version is sourced from Cargo.toml rather than setuptools or SCM.

Update the [package] version for outlines-core explicitly to ensure the correct wheel version is produced during builds and releases.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
