### PR TITLE
ODH: updated script regex 

### DIFF
--- a/r/regex/regex_ubi_9.6.sh
+++ b/r/regex/regex_ubi_9.6.sh
@@ -49,7 +49,16 @@ if ! (python3 -m pip install .) ; then
 fi
 
 # test
-if (python3 -m unittest discover); then
+cd /
+TEST_OUTPUT=$(PYTHONPATH="" python3 -m pytest -v /$PACKAGE_DIR -k "not test_main" 2>&1)
+TEST_EXIT=$?
+
+echo "$TEST_OUTPUT"
+
+if echo "$TEST_OUTPUT" | grep -q "collected 0 items"; then
+    echo "------------------$PACKAGE_NAME:No_tests_found---------------------"
+    exit 2
+elif [ $TEST_EXIT -eq 0 ]; then
     echo "------------------$PACKAGE_NAME:install_and_test_both_success-------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Pass | Both_Install_and_Test_Success"


### PR DESCRIPTION
updated scr to fix below test case issue

ERROR: regex (unittest.loader._FailedTest.regex)
----------------------------------------------------------------------
ImportError: Failed to import test module: regex
Traceback (most recent call last):
  File "/usr/lib64/python3.12/unittest/loader.py", line 429, in _find_test_path
    package = self._get_module_from_name(name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/unittest/loader.py", line 339, in _get_module_from_name
    __import__(name)
  File "/home/tester/mrab-regex/regex/__init__.py", line 1, in <module>
    import regex._main
  File "/home/tester/mrab-regex/regex/_main.py", line 427, in <module>
    from regex import _regex_core
  File "/home/tester/mrab-regex/regex/_regex_core.py", line 21, in <module>
    from regex import _regex
ImportError: cannot import name '_regex' from partially initialized module 'regex' (most likely due to a circular import) (/home/tester/mrab-regex/regex/__init__.py)


----------------------------------------------------------------------
Ran 1 test in 0.000s



## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
