### PR TITLE
OSE: added ld_library_path and fixed missing .so file issue for PyArrow v22.0.0

### DIFF
--- a/p/pyarrow/pyarrow_22.0.0_ubi_9.6.sh
+++ b/p/pyarrow/pyarrow_22.0.0_ubi_9.6.sh
@@ -74,6 +74,7 @@ make -j$(nproc)
 make install
 cd ../../python
 export BUILD_TYPE=release
+export LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH
 
 echo "Building pyarrow wheel..."
 if ! python${PYTHON_VERSION} setup.py build_ext --build-type=$BUILD_TYPE --bundle-arrow-cpp bdist_wheel ; then


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
