### PR TITLE
OSE: Modify test script to improve pytest handling for regex

### DIFF
--- a/r/regex/regex_ubi_9.6.sh
+++ b/r/regex/regex_ubi_9.6.sh
@@ -49,23 +49,17 @@ if ! (python3 -m pip install .) ; then
 fi
 
 # test
-cd /
-TEST_OUTPUT=$(PYTHONPATH="" python3 -m pytest -v /$PACKAGE_DIR -k "not test_main" 2>&1)
-TEST_EXIT=$?
-
-echo "$TEST_OUTPUT"
-
-if echo "$TEST_OUTPUT" | grep -q "collected 0 items"; then
-    echo "------------------$PACKAGE_NAME:No_tests_found---------------------"
-    exit 2
-elif [ $TEST_EXIT -eq 0 ]; then
-    echo "------------------$PACKAGE_NAME:install_and_test_both_success-------------------------"
-    echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Pass | Both_Install_and_Test_Success"
-    exit 0
-else
+# Updating unittest.main() to use exit=False because pytest treats sys.exit() from unittest.main() as a failure (SystemExit),
+# even when tests pass. This prevents pytest from failing during collection/execution.
+sed -i 's/unittest\.main(verbosity=2)/unittest.main(verbosity=2, exit=False)/' regex_3/test_regex.py
+if ! pytest; then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Fail | Install_success_but_test_Fails"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
     exit 2
+else
+    echo "------------------$PACKAGE_NAME:install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
 fi


### PR DESCRIPTION
Updated unittest.main() to prevent pytest from failing on successful tests. Adjusted output messages for clarity.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
