### PR TITLE
ODH:- Update script for Milvus-lite build failures

### DIFF
--- a/m/milvus-lite/milvus-lite_2.5.0_ubi_9.6.sh
+++ b/m/milvus-lite/milvus-lite_2.5.0_ubi_9.6.sh
@@ -32,6 +32,11 @@ yum install -y git gcc-c++ gcc wget make python3.12 yum-utils \
                libffi-devel scl-utils openblas-devel xz patch \
                python3.12-devel python3.12-pip
 
+yum install -y gcc-toolset-12
+source /opt/rh/gcc-toolset-12/enable
+gcc --version
+echo "GCC Toolset 12 activated for milvus-lite build"
+
 # Ensure python3 refers to the distro’s default (if needed)
 #ln -sf /usr/bin/python3.12 /usr/bin/python3 || true
 #ln -sf /usr/bin/pip3.12    /usr/bin/pip3   || true


### PR DESCRIPTION
Fixed issue
2026-04-01T12:30:50.5139132Z ==== Running auditwheel repair on: /home/tester/milvus_lite-2.5.0-py3-none-manylinux2014_ppc64le.whl ====
2026-04-01T12:30:50.5140850Z 
2026-04-01T12:30:50.5140871Z 
2026-04-01T12:30:50.5141399Z ===> Result of running auditwheel on the wheel:
2026-04-01T12:30:50.5142237Z 
2026-04-01T12:30:50.5143315Z INFO:auditwheel.main_repair:Repairing milvus_lite-2.5.0-py3-none-manylinux2014_ppc64le.whl
2026-04-01T12:30:50.5145202Z usage: auditwheel [-h] [-V] [-v] command ...
2026-04-01T12:30:50.5149326Z auditwheel: error: cannot repair "/home/tester/milvus_lite-2.5.0-py3-none-manylinux2014_ppc64le.whl" to "manylinux_2_41_ppc64le" ABI because of the presence of too-recent versioned symbols. You'll need to compile the wheel on an older toolchain.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
