### PR TITLE
OSE: Add build_script and build_info for xgrammar

### DIFF
--- a/x/xgrammar/LICENSE
+++ b/x/xgrammar/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/x/xgrammar/build_info.json
+++ b/x/xgrammar/build_info.json
@@ -1,0 +1,16 @@
+{
+  "maintainer": "kiranNukal",
+  "package_name": "xgrammar",
+  "github_url": "https://github.com/mlc-ai/xgrammar",
+  "version": "v0.1.33",
+  "wheel_build" : true,
+  "package_dir": "x/xgrammar",
+  "default_branch": "main",
+  "build_script": "xgrammar_ubi_9.6.sh",
+  "docker_build": false,
+  "validate_build_script": true,
+  "use_non_root_user": "false",
+  "*":{
+    "build_script":"xgrammar_ubi_9.6.sh"
+  }
+}

--- a/x/xgrammar/xgrammar_ubi_9.6.sh
+++ b/x/xgrammar/xgrammar_ubi_9.6.sh
@@ -1,0 +1,146 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+# Package       : xgrammar
+# Version       : v0.1.33
+# Source repo   : https://github.com/mlc-ai/xgrammar
+# Tested on     : UBI:9.6
+# Language      : Python
+# Script License: Apache License, Version 2 or later
+# Maintainer : Sai Kiran Nukala <sai.kiran.nukala@ibm.com>
+#
+# Disclaimer    : This script has been tested in root mode on given
+# ==========      platform using the mentioned version of the package.
+#                 It may not work as expected with newer versions of the
+#                 package and/or distribution. In such case, please
+#                 contact "Maintainer" of this script.
+# -----------------------------------------------------------------------------
+
+set -e
+
+# Variables
+PACKAGE_NAME=xgrammar
+PACKAGE_VERSION=${1:-v0.1.33}
+PACKAGE_URL=https://github.com/mlc-ai/xgrammar
+PACKAGE_DIR=xgrammar
+CURRENT_DIR=$(pwd)
+
+# -----------------------------------------------------------------------------
+# Install system dependencies required for:
+#  - building C++ bindings (gcc-toolset-13, make, cmake, ninja)
+#  - building python extensions (python3.12-devel)
+#  - building rust based dependencies (rust, cargo)
+#  - SSL and libffi support (openssl-devel, libffi-devel)
+# -----------------------------------------------------------------------------
+echo "Installing dependencies..."
+yum install -y git wget gcc-toolset-13 make cmake ninja-build \
+    python3.12 python3.12-devel python3.12-pip \
+    openssl-devel libffi-devel \
+    rust cargo
+
+# -----------------------------------------------------------------------------
+# Upgrade pip, setuptools, and wheel to avoid build failures with modern
+# pyproject.toml based projects.
+# -----------------------------------------------------------------------------
+python3.12 -m pip install --upgrade pip setuptools wheel
+
+# -----------------------------------------------------------------------------
+# Enable gcc-toolset-13.
+# This ensures the newer GCC compiler is used instead of the system default GCC,
+# which may not support newer C++ features required by xgrammar.
+# -----------------------------------------------------------------------------
+source /opt/rh/gcc-toolset-13/enable
+
+# -----------------------------------------------------------------------------
+# Install python build dependencies.
+#
+# Important:
+# - xgrammar uses C++ bindings and requires nanobind/pybind style tooling.
+# - setuptools-rust is required for building rust based python dependencies
+#   like tiktoken (dependency pulled by xgrammar).
+# - scikit-build-core is the backend used by xgrammar for building wheels.
+# - ninja/cmake are installed via pip as well to ensure compatible versions.
+# -----------------------------------------------------------------------------
+echo "Installing Python build dependencies..."
+python3.12 -m pip install pybind11 setuptools-rust build packaging pytest numpy nanobind build ninja cmake scikit-build-core
+
+cd ${CURRENT_DIR}
+
+# -----------------------------------------------------------------------------
+# Clone the repository and checkout the required version.
+# Also initialize submodules since xgrammar contains C++ components as submodules.
+# -----------------------------------------------------------------------------
+git clone $PACKAGE_URL
+cd $PACKAGE_NAME
+git checkout $PACKAGE_VERSION
+git submodule update --init --recursive
+
+# -----------------------------------------------------------------------------
+# Build C++ artifacts manually using CMake.
+# This step ensures all native libraries/bindings are generated properly.
+# Explicitly passing Python3_EXECUTABLE ensures correct python version is used.
+# -----------------------------------------------------------------------------
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/usr/bin/python3.12
+make -j$(nproc)
+cd ..
+
+# -----------------------------------------------------------------------------
+# xgrammar depends on torch. On ppc64le, torch wheels are usually not available
+# from PyPI, so installed manually using a prebuilt wheel.
+# -----------------------------------------------------------------------------
+IBM_WHEELS="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/"
+python3.12 -m pip install \
+  --prefer-binary \
+  --trusted-host wheels.developerfirst.ibm.com \
+  --extra-index-url ${IBM_WHEELS} torch==2.10.0
+
+# -----------------------------------------------------------------------------
+# scikit-build-core Build Directory Handling
+#
+# xgrammar uses scikit-build-core as its pyproject.toml backend.
+# During pip install, scikit-build-core internally invokes CMake + Ninja.
+#
+# On repeated builds, stale files (like Makefile-based artifacts) can remain
+# in the default build directory and cause Ninja to fail with:
+#   "ninja: error: Makefile: expected '=', got ':'"
+#
+# To avoid such conflicts, we enforce a clean dedicated build directory.
+# -----------------------------------------------------------------------------
+export SKBUILD_BUILD_DIR=/tmp/${PACKAGE_NAME}_skbuild
+rm -rf ${SKBUILD_BUILD_DIR}
+
+# -----------------------------------------------------------------------------
+# Force CMake generator to Ninja.
+# This ensures scikit-build-core consistently uses Ninja instead of Makefiles.
+# -----------------------------------------------------------------------------
+export CMAKE_GENERATOR=Ninja
+
+# -----------------------------------------------------------------------------
+# Install xgrammar from source.
+# --no-build-isolation ensures it uses the already installed build dependencies
+# instead of creating a separate isolated environment (prevents missing backend
+# errors like scikit_build_core.build not found).
+# -----------------------------------------------------------------------------
+if ! (python3.12 -m pip install --no-build-isolation .); then
+    echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Install_Fails"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Test Execution Notes:
+# Some tests require HuggingFace gated models.
+# If you do not have a HuggingFace token, run tests excluding those markers.
+# -----------------------------------------------------------------------------
+if ! pytest -m "not hf_token_required" ; then
+    echo " ------------------------ $PACKAGE_NAME:Both_Install_and_Test_Success ------------------------ "
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Pass |  Both_Install_and_Test_Success"
+    exit 0
+else
+    echo " ------------------------ $PACKAGE_NAME:Install_success_but_test_Fails ------------------------ "
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Fail |  Install_success_but_test_Fails"
+    exit 2
+fi

--- a/x/xgrammar/xgrammar_ubi_9.6.sh
+++ b/x/xgrammar/xgrammar_ubi_9.6.sh
@@ -135,13 +135,13 @@ fi
 # If you do not have a HuggingFace token, run tests excluding those markers.
 # -----------------------------------------------------------------------------
 if ! pytest -m "not hf_token_required" ; then
-    echo " ------------------------ $PACKAGE_NAME:Both_Install_and_Test_Success ------------------------ "
+    echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Pass |  Both_Install_and_Test_Success"
-    exit 0
-else
-    echo " ------------------------ $PACKAGE_NAME:Install_success_but_test_Fails ------------------------ "
-    echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Fail |  Install_success_but_test_Fails"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
     exit 2
+else
+    echo "------------------$PACKAGE_NAME:Install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
 fi

--- a/x/xgrammar/xgrammar_ubi_9.6.sh
+++ b/x/xgrammar/xgrammar_ubi_9.6.sh
@@ -5,6 +5,7 @@
 # Source repo   : https://github.com/mlc-ai/xgrammar
 # Tested on     : UBI:9.6
 # Language      : Python
+# Ci-Check      : True
 # Script License: Apache License, Version 2 or later
 # Maintainer : Sai Kiran Nukala <sai.kiran.nukala@ibm.com>
 #


### PR DESCRIPTION
## Summary:
Created build_script and build_info for xgrammar to enable building and testing on UBI 9.3.

### Changes Made:
- Added build_script for xgrammar v0.1.33 with required build dependencies and build steps.
- Added build_info file for xgrammar including package metadata, version, source URL, and test details.
- Included scikit-build-core build directory handling to avoid stale Makefile/Ninja conflicts during pip install.
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
