### PR TITLE
fix(gha-dns): Remove 'network' parameter from container run command in build scripts

### DIFF
--- a/gha-script/build_wheels.py
+++ b/gha-script/build_wheels.py
@@ -35,7 +35,6 @@ def trigger_build_wheel(wrapper_file, python_version, image_name, file_name, ver
         container = client.containers.run(
             image_name,
             command,
-            network='host',
             detach=True,
             volumes={current_dir: {'bind': '/home/tester/', 'mode': 'rw'}},  # Mount current directory with both files
             stderr=True,

--- a/gha-script/trigger_container.py
+++ b/gha-script/trigger_container.py
@@ -40,7 +40,6 @@ def trigger_script_validation_checks(image_name = "registry.access.redhat.com/ub
     container = client.containers.run(
         image_name,
         "/home/tester/{}".format(file_name),
-        network = 'host',
         detach = True,
         volumes = {
             current_dir : {'bind': '/home/tester/', 'mode': 'rw'}

--- a/gha-script/validate_builds.py
+++ b/gha-script/validate_builds.py
@@ -171,7 +171,6 @@ def trigger_script_validation_checks(file_name):
         container = client.containers.run(
             image_name,
             "/home/tester/{}".format(file_name),
-            network = 'host',
             detach = True,
             volumes = {
                 current_dir : {'bind': '/home/tester/', 'mode': 'rw'}

--- a/gha-script/validate_builds_currency.py
+++ b/gha-script/validate_builds_currency.py
@@ -29,7 +29,6 @@ def trigger_script_validation_checks(file_name, version, image_name):
             container = client.containers.run(
                 image=image_name,
                 command=command,
-                network='host',
                 detach=True,
                 volumes={current_dir: {'bind': '/home/tester/', 'mode': 'rw'}},
                 stderr=True,


### PR DESCRIPTION
This PR removes the `network='host'` parameter from Docker container configurations in Python scripts used for GitHub Actions workflows.

By removing `network='host'`, containers will now use Docker's default bridge networking instead of sharing the host's network stack. This provides better network isolation and follows Docker security best practices.