### PR TITLE
Updated the build script for ml-metadata 

### DIFF
--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -66,9 +66,7 @@ git checkout $PACKAGE_VERSION
 sed -i '/j2objc/d' WORKSPACE
 
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/m/ml-metadata/ml_metadata_ubi9.6.patch
-#git apply ml_metadata_ubi9.6.patch
-#git apply ml_metadata_ubi9.6.patch --reject || true
-git apply --ignore-whitespace ml_metadata_ubi9.6.patch
+git apply ml_metadata_ubi9.6.patch --reject || true
 
 #update zetasql hash and strip_prefix to match actual archive
 sed -i 's/651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840/86f81591ab5ec20457a5394eb2c5c981e6f6c89f4c49c211d096c3acffec1eb1/g' WORKSPACE

--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -66,7 +66,9 @@ git checkout $PACKAGE_VERSION
 sed -i '/j2objc/d' WORKSPACE
 
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/m/ml-metadata/ml_metadata_ubi9.6.patch
-git apply ml_metadata_ubi9.6.patch
+#git apply ml_metadata_ubi9.6.patch
+#git apply ml_metadata_ubi9.6.patch --reject || true
+git apply --ignore-whitespace ml_metadata_ubi9.6.patch
 
 #update zetasql hash and strip_prefix to match actual archive
 sed -i 's/651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840/86f81591ab5ec20457a5394eb2c5c981e6f6c89f4c49c211d096c3acffec1eb1/g' WORKSPACE

--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -99,7 +99,19 @@ if ! (python3.11 -m pip install .); then
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_fails"
      exit 2;
-elif ! pytest -vv; then
+fi
+
+if ! python3.11 -m build --wheel --no-isolation --outdir="$wdir/"; then
+        echo "============ Wheel Creation Failed for Python $PYTHON_VERSION (without isolation) ================="
+        echo "Attempting to build with isolation..."
+
+        # Attempt to build the wheel without isolation
+        if ! python3.11 -m build --wheel --outdir="$wdir/"; then
+            echo "============ Wheel Creation Failed for Python $PYTHON_VERSION ================="
+        fi
+fi
+
+if ! pytest -vv; then
      echo "------------------$PACKAGE_NAME:Test_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_success_but_test_Fails"
@@ -108,8 +120,5 @@ else
      echo "------------------$PACKAGE_NAME:Build_and_test_both_success-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Pass |  Both_Build_and_Test_Success"
-     #Build wheel for wrapper's collection step
-     python3.11 -m build --wheel --no-isolation --outdir=$wdir/ || \
-         python3.11 -m build --wheel --outdir=$wdir/
      exit 0;
 fi

--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -31,7 +31,8 @@ SCRIPT=$(readlink -f $0)
 SCRIPT_DIR=$(dirname $SCRIPT)
 
 #Install the dependencies
-yum install -y autoconf cmake wget automake libtool zlib zlib-devel libjpeg libjpeg-devel gcc-toolset-13 python3.11 python3.11-pip python3.11-devel git unzip zip patch openssl-devel utf8proc tzdata diffutils libffi-devel
+#added gcc-toolset-13-binutils, gcc, gcc-c++ to resolve linker issues
+yum install -y autoconf cmake wget automake libtool zlib zlib-devel libjpeg libjpeg-devel gcc gcc-c++ gcc-toolset-13 gcc-toolset-13-binutils python3.11 python3.11-pip python3.11-devel git unzip zip patch openssl-devel utf8proc tzdata diffutils libffi-devel
 source /opt/rh/gcc-toolset-13/enable
 
 yum install -y java-11-openjdk-devel
@@ -49,30 +50,66 @@ bazel --version
 cd $wdir
 
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
-python3.11 -m pip install numpy pytest
+python3.11 -m pip install --upgrade pip
+python3.11 -m pip install numpy pytest build
+
+#ensure bare 'python' resolves to python3.11
+if ! command -v python &>/dev/null; then
+    ln -sf /usr/bin/python3.11 /usr/local/bin/python
+fi
 
 git clone $PACKAGE_URL
 cd $PACKAGE_NAME/
+git checkout $PACKAGE_VERSION
+
+#remove j2objc reference that causes fetch failure
+sed -i '/j2objc/d' WORKSPACE
+
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/m/ml-metadata/ml_metadata_ubi9.6.patch
 git apply ml_metadata_ubi9.6.patch
 
+#update zetasql hash and strip_prefix to match actual archive
+sed -i 's/651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840/86f81591ab5ec20457a5394eb2c5c981e6f6c89f4c49c211d096c3acffec1eb1/g' WORKSPACE
+sed -i 's/strip_prefix = "zetasql-/strip_prefix = "googlesql-/g' WORKSPACE
+
+#set correct PYTHON_LIB_PATH 
 export PYTHON_BIN_PATH=$(which python3.11)
+export PYTHON_LIB_PATH=$(python3.11 -c "import sysconfig; print(sysconfig.get_path('stdlib'))")
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:/usr/lib64:/usr/lib
+
+#pre-fetch libmysqlclient and patch its cmake invocation to use system
+#gcc (/usr/bin/gcc) instead of gcc-toolset-13's cc, which requires
+#LIBCTF_1.1 from libctf.so.0 — a version not present on this system.
+bazel fetch @libmysqlclient//... 2>/dev/null || true
+LIBMYSQL_BUILD=$(find /root/.cache/bazel -name "BUILD.bazel" -path "*/libmysqlclient/*" 2>/dev/null | head -1)
+if [ -n "$LIBMYSQL_BUILD" ]; then
+    sed -i 's|cmake \.\. -DCMAKE_BUILD_TYPE=Release \${CMAKE_ICONV_FLAG-}|cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ ${CMAKE_ICONV_FLAG-}|g' "$LIBMYSQL_BUILD"
+    echo "Patched libmysqlclient cmake: $(grep 'cmake \.\.' $LIBMYSQL_BUILD)"
+else
+    echo "ERROR: Could not find libmysqlclient BUILD.bazel to patch"
+    exit 1
+fi
+
+#keep only build artifacts clean, preserve fetched repos
+bazel clean 2>/dev/null || true
 
 if ! (python3.11 -m pip install .); then 
      echo "------------------$PACKAGE_NAME:Build_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_fails"
      exit 2;
-
 elif ! pytest -vv; then
      echo "------------------$PACKAGE_NAME:Test_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_success_but_test_Fails"
      exit 1;
-
 else
      echo "------------------$PACKAGE_NAME:Build_and_test_both_success-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Pass |  Both_Build_and_Test_Success"
+     #Build wheel for wrapper's collection step
+     python3.11 -m build --wheel --no-isolation --outdir=$wdir/ || \
+         python3.11 -m build --wheel --outdir=$wdir/
      exit 0;
 fi


### PR DESCRIPTION
### Added fixes for the issues:
- Added missing system packages to yum install (gcc, gcc-c++, gcc-toolset-13-binutils)
```
/opt/rh/gcc-toolset-13/root/usr/libexec/gcc/ppc64le-redhat-linux/13/ld:
/usr/lib64/libctf.so.0: version `LIBCTF_1.1' not found
collect2: error: ld returned 1 exit status
```
- added build package, added python symlink
```
/usr/bin/python: No module named build.__main__; 'build' is a package
and cannot be directly executed
```
- Added explicit git checkout for the target version
- Removed j2objc from WORKSPACE (as there is not ppc64le build for it and is not needed for the package).
```
ERROR: An error occurred during the fetch of repository 'j2objc_runtime':
   Traceback (most recent call last):
        ...
   Error in fail: Repository j2objc_runtime not found
```
-  Fixed zetasql archive SHA256 hash
```
Error downloading zetasql archive:
SHA256 hash mismatch:
  expected: 651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840
  got:      86f81591ab5ec20457a5394eb2c5c981e6f6c89f4c49c211d096c3acffec1eb1
```
- Fixed zetasql strip_prefix to match renamed archive directory
```
ERROR: error extracting package: 
  error reading .../zetasql.zip: 
  could not find directory 'zetasql-<version>' 
  in zip file; perhaps the zip file's directory structure 
  does not match the expected strip_prefix
```
- Set correct PYTHON_LIB_PATH and additional Python environment variables
```
Error in fail: Python Configuration Error: Invalid python library path:
/usr/lib64/libpython3.11.so.1.0
```
- Pre-fetch and patch libmysqlclient BUILD.bazel to use system gcc in cmake
```
ERROR: /root/.cache/bazel/_bazel_root/29613bceb191ac03fa64432215d9ae21/external/libmysqlclient/BUILD.bazel:14:8: 
Executing genrule @libmysqlclient//:configure failed: (Exit 1): bash failed: error executing command 
(from target @libmysqlclient//:configure)
CMake Deprecation Warning at CMakeLists.txt:5 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.
CMake Error at /usr/share/cmake/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler
    "/opt/rh/gcc-toolset-13/root/usr/bin/cc"
  is not able to compile a simple test program.
  It fails with the following output:
    /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/ppc64le-redhat-linux/13/ld: 
    /usr/lib64/libctf.so.0: version `LIBCTF_1.1' not found 
    (required by /opt/rh/gcc-toolset-13/root/usr/libexec/gcc/ppc64le-redhat-linux/13/ld)
    collect2: error: ld returned 1 exit status
  CMake will not be able to correctly generate this project.
-- Check for working C compiler: /opt/rh/gcc-toolset-13/root/usr/bin/cc - broken
-- Configuring incomplete, errors occurred!
Target //ml_metadata:move_generated_files failed to build
FAILED: Build did NOT complete successfully
```

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
