### PR TITLE
Update OpenBLAS version to 0.3.32 on outlines core

### DIFF
--- a/o/outlines-core/outlines-core_ubi_9.3.sh
+++ b/o/outlines-core/outlines-core_ubi_9.3.sh
@@ -52,48 +52,10 @@ cd ..
 cd $CURRENT_DIR
 git clone https://github.com/OpenMathLib/OpenBLAS
 cd OpenBLAS
-git checkout v0.3.29
-git submodule update --init
-
-# Set install prefix inside the OpenBLAS directory
-OPENBLAS_PREFIX=$(pwd)/local
-mkdir -p "${OPENBLAS_PREFIX}"
-# Set build options
-declare -a build_opts
-# Fix ctest not automatically discovering tests
-LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
-export CF="${CFLAGS} -Wno-unused-parameter -Wno-old-style-declaration"
-unset CFLAGS
-export USE_OPENMP=1
-build_opts+=(USE_OPENMP=${USE_OPENMP})
-# Handle Fortran flags
-if [ ! -z "$FFLAGS" ]; then
-    export FFLAGS="${FFLAGS/-fopenmp/ }"
-    export FFLAGS="${FFLAGS} -frecursive"
-    export LAPACK_FFLAGS="${FFLAGS}"
-fi
-export PLATFORM=$(uname -m)
-build_opts+=(BINARY="64")
-build_opts+=(DYNAMIC_ARCH=1)
-build_opts+=(TARGET="POWER9")
-BUILD_BFLOAT16=1
-# Placeholder for future builds that may include ILP64 variants.
-build_opts+=(INTERFACE64=0)
-build_opts+=(SYMBOLSUFFIX="")
-# Build LAPACK
-build_opts+=(NO_LAPACK=0)
-# Enable threading and set the number of threads
-build_opts+=(USE_THREAD=1)
-build_opts+=(NUM_THREADS=8)
-# Disable CPU/memory affinity handling to avoid problems with NumPy and R
-build_opts+=(NO_AFFINITY=1)
-# Build OpenBLAS
-make ${build_opts[@]} CFLAGS="${CF}" FFLAGS="${FFLAGS}" prefix=${OPENBLAS_PREFIX}
-# Install OpenBLAS
-CFLAGS="${CF}" FFLAGS="${FFLAGS}" make install PREFIX="${OPENBLAS_PREFIX}" ${build_opts[@]}
-export LD_LIBRARY_PATH=${OPENBLAS_PREFIX}/lib:$LD_LIBRARY_PATH
-export PKG_CONFIG_PATH=${OPENBLAS_PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH
-pkg-config --modversion openblas
+git checkout v0.3.32
+make -j${MAX_JOBS} TARGET=POWER9 BUILD_BFLOAT16=1 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
+make install
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64:/usr/local/lib
 cd $CURRENT_DIR
 
 
@@ -186,7 +148,6 @@ export LDFLAGS="$(echo ${LDFLAGS} | sed -e 's/-Wl\,--as-needed//')"
 export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${VIRTUAL_ENV}/lib"
 export CXXFLAGS="${CXXFLAGS} -fplt"
 export CFLAGS="${CFLAGS} -fplt"
-export BLAS=OpenBLAS
 export USE_FBGEMM=0
 export USE_SYSTEM_NCCL=1
 export USE_MKLDNN=0
@@ -218,11 +179,6 @@ export LD_LIBRARY_PATH=/pytorch/build/lib/libprotobuf.so.3.13.0.0:$LD_LIBRARY_PA
 export PATH="/protobuf/local/libprotobuf/bin/protoc:${PATH}"
 export LD_LIBRARY_PATH="/protobuf/local/libprotobuf/lib64:${LD_LIBRARY_PATH}"
 export LD_LIBRARY_PATH="/protobuf/third_party/abseil-cpp/local/abseilcpp/lib:${LD_LIBRARY_PATH}"
-export LD_LIBRARY_PATH=$OPENBLAS_PREFIX/lib:$LD_LIBRARY_PATH
-export CPATH=$OPENBLAS_PREFIX/include:$CPATH
-export OpenBLAS_INCLUDE_DIR=$OPENBLAS_PREFIX/include
-export OpenBLAS_LIB_DIR=$OPENBLAS_PREFIX/lib
-export OpenBLAS_HOME=$OPENBLAS_PREFIX
 
 
 # Fix CMake version requirement
@@ -748,7 +704,6 @@ cd $CURRENT_DIR
 git clone -b $PACKAGE_VERSION $PACKAGE_URL
 cd $PACKAGE_NAME
 
-export LD_LIBRARY_PATH=$OPENBLAS_PREFIX/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH="${RE2_PREFIX}/lib:$LD_LIBRARY_PATH"
 
 python3.12 -m pip install setuptools pytest pydantic pytest-cov pandas


### PR DESCRIPTION
```
uild/ring-dbbc84449eff4f3b/out`
   Compiling tokenizers v0.20.3
     Running `/root/.rustup/toolchains/stable-powerpc64le-unknown-linux-gnu/bin/rustc --crate-name tokenizers --edition=2018 /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokenizers-0.20.3/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=124 --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C panic=abort -C linker-plugin-lto -C codegen-units=1 --cfg 'feature="default"' --cfg 'feature="esaxx_fast"' --cfg 'feature="hf-hub"' --cfg 'feature="http"' --cfg 'feature="indicatif"' --cfg 'feature="onig"' --cfg 'feature="progressbar"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "esaxx_fast", "fancy-regex", "hf-hub", "http", "indicatif", "onig", "progressbar", "unstable_wasm"))' -C metadata=e5794ce3918f77ee -C extra-filename=-b0fadc15ed8586b9 --out-dir /build-scripts/outlines-core/target/release/deps -C strip=symbols -L dependency=/build-scripts/outlines-core/target/release/deps --extern aho_corasick=/build-scripts/outlines-core/target/release/deps/libaho_corasick-244cf402590a8748.rmeta --extern derive_builder=/build-scripts/outlines-core/target/release/deps/libderive_builder-066e501884b74b33.rmeta --extern esaxx_rs=/build-scripts/outlines-core/target/release/deps/libesaxx_rs-1ace8ec60aafb906.rmeta --extern getrandom=/build-scripts/outlines-core/target/release/deps/libgetrandom-c683f8e15e582f31.rmeta --extern hf_hub=/build-scripts/outlines-core/target/release/deps/libhf_hub-d76812855ec682f8.rmeta --extern indicatif=/build-scripts/outlines-core/target/release/deps/libindicatif-4a3bacaefab51bc3.rmeta --extern itertools=/build-scripts/outlines-core/target/release/deps/libitertools-1713c763b84c03ff.rmeta --extern lazy_static=/build-scripts/outlines-core/target/release/deps/liblazy_static-f1d78fb31a1d17b3.rmeta --extern log=/build-scripts/outlines-core/target/release/deps/liblog-97aed578626b5e07.rmeta --extern macro_rules_attribute=/build-scripts/outlines-core/target/release/deps/libmacro_rules_attribute-d6ce6af1c5446e3b.rmeta --extern monostate=/build-scripts/outlines-core/target/release/deps/libmonostate-3432611347677126.rmeta --extern onig=/build-scripts/outlines-core/target/release/deps/libonig-bd15f3ef5eb2c9ec.rmeta --extern paste=/build-scripts/outlines-core/target/release/deps/libpaste-ea3cfe8b83d05f83.so --extern rand=/build-scripts/outlines-core/target/release/deps/librand-111df74ba026fe07.rmeta --extern rayon=/build-scripts/outlines-core/target/release/deps/librayon-780fefc48c148e34.rmeta --extern rayon_cond=/build-scripts/outlines-core/target/release/deps/librayon_cond-016754112025d622.rmeta --extern regex=/build-scripts/outlines-core/target/release/deps/libregex-d080c7b31291181e.rmeta --extern regex_syntax=/build-scripts/outlines-core/target/release/deps/libregex_syntax-8e0cd45fcebd036e.rmeta --extern serde=/build-scripts/outlines-core/target/release/deps/libserde-18fcf21c911ddd67.rmeta --extern serde_json=/build-scripts/outlines-core/target/release/deps/libserde_json-1f17da200e8813dc.rmeta --extern spm_precompiled=/build-scripts/outlines-core/target/release/deps/libspm_precompiled-820b47a1c6fdec8e.rmeta --extern thiserror=/build-scripts/outlines-core/target/release/deps/libthiserror-3b35e760d83b561c.rmeta --extern unicode_normalization_alignments=/build-scripts/outlines-core/target/release/deps/libunicode_normalization_alignments-6579b1599968187b.rmeta --extern unicode_segmentation=/build-scripts/outlines-core/target/release/deps/libunicode_segmentation-0e2f123c17491839.rmeta --extern unicode_categories=/build-scripts/outlines-core/target/release/deps/libunicode_categories-635dc47aedd30e49.rmeta --cap-lints allow -L native=/build-scripts/outlines-core/target/release/build/esaxx-rs-bf19daed6980388c/out -L native=/build-scripts/outlines-core/target/release/build/ring-dbbc84449eff4f3b/out -L native=/build-scripts/outlines-core/target/release/build/onig_sys-6356cc5de76c610c/out`
   Compiling outlines-core v0.1.26 (/build-scripts/outlines-core)
     Running `/root/.rustup/toolchains/stable-powerpc64le-unknown-linux-gnu/bin/rustc --crate-name outlines_core --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=124 --crate-type cdylib --emit=dep-info,link -C opt-level=3 -C panic=abort -C lto -C codegen-units=1 --warn=unexpected_cfgs --check-cfg 'cfg(tarpaulin_include)' --cfg 'feature="pyo3"' --cfg 'feature="python-bindings"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("pyo3", "python-bindings"))' -C metadata=1cfa87112a0b13aa --out-dir /build-scripts/outlines-core/target/release/deps -C strip=symbols -L dependency=/build-scripts/outlines-core/target/release/deps --extern bincode=/build-scripts/outlines-core/target/release/deps/libbincode-0e81ba760aaa9cde.rlib --extern hf_hub=/build-scripts/outlines-core/target/release/deps/libhf_hub-d76812855ec682f8.rlib --extern once_cell=/build-scripts/outlines-core/target/release/deps/libonce_cell-31c1327f90173a58.rlib --extern pyo3=/build-scripts/outlines-core/target/release/deps/libpyo3-0835a29908ed3ff4.rlib --extern regex=/build-scripts/outlines-core/target/release/deps/libregex-d080c7b31291181e.rlib --extern rustc_hash=/build-scripts/outlines-core/target/release/deps/librustc_hash-3208b3ad8d98e203.rlib --extern serde=/build-scripts/outlines-core/target/release/deps/libserde-18fcf21c911ddd67.rlib --extern serde_pyobject=/build-scripts/outlines-core/target/release/deps/libserde_pyobject-021523d4a2dd252b.rlib --extern serde_json=/build-scripts/outlines-core/target/release/deps/libserde_json-1f17da200e8813dc.rlib --extern thiserror=/build-scripts/outlines-core/target/release/deps/libthiserror-5a4a90ada0e99479.rlib --extern tokenizers=/build-scripts/outlines-core/target/release/deps/libtokenizers-b0fadc15ed8586b9.rlib --crate-type=cdylib -L native=/build-scripts/outlines-core/target/release/build/ring-dbbc84449eff4f3b/out -L native=/build-scripts/outlines-core/target/release/build/esaxx-rs-bf19daed6980388c/out -L native=/build-scripts/outlines-core/target/release/build/onig_sys-6356cc5de76c610c/out`
    Finished `release` profile [optimized] target(s) in 1m 10s
Copying rust artifact from target/release/liboutlines_core.so to build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/outlines_core_rs.cpython-311-powerpc64le-linux-gnu.so
installing to build/bdist.linux-ppc64le/wheel
running install
running install_lib
creating build/bdist.linux-ppc64le/wheel
creating build/bdist.linux-ppc64le/wheel/outlines_core
copying build/lib.linux-ppc64le-cpython-311/outlines_core/__init__.py -> build/bdist.linux-ppc64le/wheel/./outlines_core
copying build/lib.linux-ppc64le-cpython-311/outlines_core/_version.py -> build/bdist.linux-ppc64le/wheel/./outlines_core
copying build/lib.linux-ppc64le-cpython-311/outlines_core/py.typed -> build/bdist.linux-ppc64le/wheel/./outlines_core
creating build/bdist.linux-ppc64le/wheel/outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/__init__.py -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/guide.py -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/json_schema.py -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/outlines_core_rs.pyi -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/regex.py -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
copying build/lib.linux-ppc64le-cpython-311/outlines_core/fsm/outlines_core_rs.cpython-311-powerpc64le-linux-gnu.so -> build/bdist.linux-ppc64le/wheel/./outlines_core/fsm
running install_egg_info
Copying python/outlines_core.egg-info to build/bdist.linux-ppc64le/wheel/./outlines_core-0.1.27.dev0+g241a53bc4.d20260415-py3.11.egg-info
running install_scripts
creating build/bdist.linux-ppc64le/wheel/outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/WHEEL
creating '/build-scripts/.tmp-8ux6rk4_/outlines_core-0.1.27.dev0+g241a53bc4.d20260415-cp311-cp311-linux_ppc64le.whl' and adding 'build/bdist.linux-ppc64le/wheel' to it
adding 'outlines_core/__init__.py'
adding 'outlines_core/_version.py'
adding 'outlines_core/py.typed'
adding 'outlines_core/fsm/__init__.py'
adding 'outlines_core/fsm/guide.py'
adding 'outlines_core/fsm/json_schema.py'
adding 'outlines_core/fsm/outlines_core_rs.cpython-311-powerpc64le-linux-gnu.so'
adding 'outlines_core/fsm/outlines_core_rs.pyi'
adding 'outlines_core/fsm/regex.py'
adding 'outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/licenses/LICENSE'
adding 'outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/METADATA'
adding 'outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/WHEEL'
adding 'outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/top_level.txt'
adding 'outlines_core-0.1.27.dev0+g241a53bc4.d20260415.dist-info/RECORD'
removing build/bdist.linux-ppc64le/wheel
Successfully built outlines_core-0.1.27.dev0+g241a53bc4.d20260415-cp311-cp311-linux_ppc64le.whl
=============== Modifying Metadata file ==================
Added IBM classifier to outlines_core-0.1.27.dev0+g241a53bc4.d20260415-cp311-cp311-linux_ppc64le.whl
```