### PR TITLE
Updated ml-metadata build script 

### DIFF
--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -66,6 +66,8 @@ git checkout $PACKAGE_VERSION
 sed -i '/j2objc/d' WORKSPACE
 
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/m/ml-metadata/ml_metadata_ubi9.6.patch
+sed -i 's/ \+\t/\t/g' ml_metadata_ubi9.6.patch
+sed -i 's/[[:space:]]\+$//' ml_metadata_ubi9.6.patch
 git apply ml_metadata_ubi9.6.patch --reject || true
 
 #update zetasql hash and strip_prefix to match actual archive

--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -98,7 +98,7 @@ if ! (python3.11 -m pip install .); then
      echo "------------------$PACKAGE_NAME:Build_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_fails"
-     return 0 2>/dev/null || exit 0
+     return 2 2>/dev/null || exit 2
 fi
 
 if ! python3.11 -m build --wheel --no-isolation --outdir="$wdir/"; then

--- a/m/ml-metadata/ml-metadata_ubi_9.6.sh
+++ b/m/ml-metadata/ml-metadata_ubi_9.6.sh
@@ -98,7 +98,7 @@ if ! (python3.11 -m pip install .); then
      echo "------------------$PACKAGE_NAME:Build_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_fails"
-     exit 2;
+     return 0 2>/dev/null || exit 0
 fi
 
 if ! python3.11 -m build --wheel --no-isolation --outdir="$wdir/"; then
@@ -115,10 +115,10 @@ if ! pytest -vv; then
      echo "------------------$PACKAGE_NAME:Test_fails-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Fail |  Build_success_but_test_Fails"
-     exit 1;
+     return 1 2>/dev/null || exit 1
 else
      echo "------------------$PACKAGE_NAME:Build_and_test_both_success-------------------------------------"
      echo "$PACKAGE_URL $PACKAGE_NAME"
      echo "$PACKAGE_NAME  |  $PACKAGE_URL  | $PACKAGE_VERSION | GitHub | Pass |  Both_Build_and_Test_Success"
-     exit 0;
+    return 0 2>/dev/null || exit 0
 fi


### PR DESCRIPTION
### Issue: 
Wheel file was getting store in the working directory but the wrapper wasn't able to detect it .

### Fix:
Previously, the script exited immediately after successful test execution, preventing the wrapper from detecting wheel in the working directory.

Replaced:

```bash
exit 0
```

With:

```bash
return 0 2>/dev/null || exit 0
```

This allows sourced execution to return control to the wrapper, while still exiting normally when run directly. No changes to build or test logic.




## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
