### PR TITLE
Remove rotten_tomatoes dataset from CatBoost 1.2.7 for OSSC compliance

### DIFF
--- a/c/catboost/Dockerfiles/v1.2.7_ubi_9.6/Dockerfile
+++ b/c/catboost/Dockerfiles/v1.2.7_ubi_9.6/Dockerfile
@@ -103,6 +103,10 @@ RUN set -ex \
 && grep -n 'yasm/1.3.0' "$CONANFILE" || true \
 && grep -n 'ragel/6.10' "$CONANFILE" || true \
 \
+&& echo -e "\n[+] Remove rotten_tomatoes dataset function\n" \
+&& DATASETS_FILE="$REPO_DIR/catboost/python-package/catboost/datasets.py" \
+&& sed -i '/^def rotten_tomatoes():/,/^def /{/^def rotten_tomatoes():/!{/^def /!d}}; /^def rotten_tomatoes():/d' "$DATASETS_FILE" \
+\
 && RAGEL_BUILD="$WORKDIR/_ragel_build" \
 && rm -rf "$RAGEL_BUILD" \
 && mkdir -p "$RAGEL_BUILD" \

--- a/c/catboost/catboost-1.2.7_ubi_9.6.sh
+++ b/c/catboost/catboost-1.2.7_ubi_9.6.sh
@@ -146,6 +146,13 @@ grep -n 'yasm/1.3.0' "$CONANFILE" || true
 grep -n 'ragel/6.10' "$CONANFILE" || true
 
 # ----------------------------------------------------------------------------
+# Remove rotten_tomatoes dataset function
+# ----------------------------------------------------------------------------
+
+DATASETS_FILE="$REPO_DIR/catboost/python-package/catboost/datasets.py"
+sed -i '/^def rotten_tomatoes():/,/^def /{/^def rotten_tomatoes():/!{/^def /!d}}; /^def rotten_tomatoes():/d' "$DATASETS_FILE"
+
+# ----------------------------------------------------------------------------
 # Build ragel from source
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [x] Did you have **Legal approvals** for patch files ? 
