### PR TITLE
Added fix for license metadata in pyproject.toml

### DIFF
--- a/s/sentencepiece/sentencepiece_0.2.0_ubi_9.3.sh
+++ b/s/sentencepiece/sentencepiece_0.2.0_ubi_9.3.sh
@@ -124,6 +124,27 @@ git clone $PACKAGE_URL
 cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 
+echo "-------------------------- Patch license metadata --------------------------"
+cd python
+
+cp -f ../LICENSE . 2>/dev/null || true
+
+if ! grep -q '^license *=.*' pyproject.toml; then
+    echo "Patching pyproject.toml to include license..."
+
+    sed -i '/^\[project\]$/a license = "Apache-2.0"' pyproject.toml
+    sed -i '/^license = "Apache-2.0"$/a license-files = ["LICENSE"]' pyproject.toml
+fi
+
+# Ensure LICENSE included in source dist
+if [ ! -f MANIFEST.in ]; then
+    echo "include LICENSE" > MANIFEST.in
+elif ! grep -q LICENSE MANIFEST.in; then
+    echo "include LICENSE" >> MANIFEST.in
+fi
+
+cd ..
+
 export PATH="$LIBPROTO_INSTALL/bin:${PATH}"
 export LD_LIBRARY_PATH="$LIBPROTO_INSTALL/lib:${LD_LIBRARY_PATH}"
 export CMAKE_PREFIX_PATH="$LIBPROTO_INSTALL"  # ADDED: Let CMake find protobuf/abseil


### PR DESCRIPTION
## Fixed license issue for sentencepiece wheel:
-  Copied `LICENSE` to sentencepiece/python/ directory as it was not present in this folder
-  Added `license = "Apache-2.0"` to `python/pyproject.toml`
- Added `license-files = ["LICENSE"]` to `python/pyproject.toml`
- Updated `MANIFEST.in` to include `LICENSE`
- Ensured final wheel contains correct license metadata and bundled LICENSE file
```
[root@823ef4341b91 home]# unzip -l /home/wheelhouse/*.whl | grep -i license
    11358  04-22-2026 06:59   sentencepiece-0.2.1+ppc64le1.dist-info/licenses/LICENSE
[root@823ef4341b91 home]# unzip -p /home/wheelhouse/*.whl '*.dist-info/METADATA' | grep -i License
License-Expression: Apache-2.0
License-File: LICENSE
Dynamic: license-file
[root@823ef4341b91 home]# 
```


## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
