### PR TITLE
Fix OpenBLAS wheel build error and update platform tag to linux_ppc64le

### DIFF
--- a/o/openblas/openblas_ubi_9.3.sh
+++ b/o/openblas/openblas_ubi_9.3.sh
@@ -1,8 +1,8 @@
-#!/bin/bash 
+#!/bin/bash
 # -----------------------------------------------------------------------------
 #
 # Package         : OpenBLAS
-# Version         : v0.3.32
+# Version         : v0.3.29
 # Source repo     : https://github.com/OpenMathLib/OpenBLAS
 # Tested on       : UBI: 9.3
 # Language        : C
@@ -27,7 +27,6 @@ PACKAGE_URL=https://github.com/OpenMathLib/OpenBLAS
 OPENBLAS_VERSION=${PACKAGE_VERSION}
 CURRENT_DIR=$(pwd)
 PACKAGE_DIR=OpenBLAS
-MAX_JOBS=${MAX_JOBS:-8}
 
 
 echo "------------------------Installing dependencies-------------------"
@@ -52,73 +51,74 @@ git submodule update --init
 
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/o/openblas/pyproject.toml
 sed -i "s/{PACKAGE_VERSION}/$(echo $PACKAGE_VERSION | sed 's/^v//')/g" pyproject.toml
-echo "--------------------------replaced version in pyproject.toml--------------------------"
+sed -i 's/manylinux2014_ppc64le/linux_ppc64le/g' pyproject.toml
+echo "--------------------------replaced version and platform tag in pyproject.toml--------------------------"
 
-export USE_OPENMP=1
-export USE_THREAD=1
-export NUM_THREADS=120
-export TARGET=POWER9
-export DYNAMIC_ARCH=1
-export INTERFACE64=0
-export BUILD_BFLOAT16=1
-export NO_AFFINITY=1
+# Create the local directory structure expected by pyproject.toml
+mkdir -p local/openblas
+PREFIX=local/openblas
 
-# Fix flags
+# Set build options
+declare -a build_opts
+
+# Fix ctest not automatically discovering tests
+LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
+
+# See this workaround: https://github.com/xianyi/OpenBLAS/issues/818#issuecomment-207365134
 export CF="${CFLAGS} -Wno-unused-parameter -Wno-old-style-declaration"
 unset CFLAGS
 
-# Remove problematic linker flag if present
-LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
+export USE_OPENMP=1
+build_opts+=(USE_OPENMP=${USE_OPENMP})
+export PREFIX=${PREFIX}
 
-# -----------------------------------------------------------------------------
-# Build
-# -----------------------------------------------------------------------------
-if ! make -j${MAX_JOBS} \
-    TARGET=${TARGET} \
-    BUILD_BFLOAT16=${BUILD_BFLOAT16} \
-    BINARY=64 \
-    USE_OPENMP=${USE_OPENMP} \
-    USE_THREAD=${USE_THREAD} \
-    NUM_THREADS=${NUM_THREADS} \
-    DYNAMIC_ARCH=${DYNAMIC_ARCH} \
-    INTERFACE64=${INTERFACE64} \
-    NO_AFFINITY=${NO_AFFINITY} \
-    CFLAGS="${CF}" ; then
+# Handle Fortran flags
+if [ ! -z "$FFLAGS" ]; then
+    export FFLAGS="${FFLAGS/-fopenmp/ }"
+    export FFLAGS="${FFLAGS} -frecursive"
+    export LAPACK_FFLAGS="${FFLAGS}"
+fi
 
+export PLATFORM=$(uname -m)
+build_opts+=(BINARY="64")
+build_opts+=(DYNAMIC_ARCH=1)
+build_opts+=(TARGET="POWER9")
+BUILD_BFLOAT16=1
+
+# Placeholder for future builds that may include ILP64 variants.
+build_opts+=(INTERFACE64=0)
+build_opts+=(SYMBOLSUFFIX="")
+
+# Build LAPACK
+build_opts+=(NO_LAPACK=0)
+
+# Enable threading and set the number of threads
+build_opts+=(USE_THREAD=1)
+build_opts+=(NUM_THREADS=120)
+
+# Disable CPU/memory affinity handling to avoid problems with NumPy and R
+build_opts+=(NO_AFFINITY=1)
+
+# Build OpenBLAS
+if ! (make -j8 ${build_opts[@]} CFLAGS="${CF}" FFLAGS="${FFLAGS}" prefix=${PREFIX}) ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
     exit 1
 fi
 
-# -----------------------------------------------------------------------------
 # Install OpenBLAS
-# -----------------------------------------------------------------------------
-echo "------------------------Installing OpenBLAS-------------------"
+CFLAGS="${CF}" FFLAGS="${FFLAGS}" make install PREFIX="${PREFIX}" ${build_opts[@]}
 
-if ! make install PREFIX=${PREFIX} ; then
+#install
+if ! (pip install . --no-build-isolation) ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
     exit 1
 fi
 
-# -----------------------------------------------------------------------------
-# Library path setup
-# -----------------------------------------------------------------------------
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PREFIX}/lib64:${PREFIX}/lib
-
-# -----------------------------------------------------------------------------
-# Python package install (from original script)
-# -----------------------------------------------------------------------------
-echo "------------------------Installing Python package-------------------"
-
-if ! pip install . --no-build-isolation ; then
-    echo "------------------$PACKAGE_NAME:Python_Install_fails-------------------------------------"
-    exit 1
-fi
-
-# -----------------------------------------------------------------------------
-# Run tests
-# -----------------------------------------------------------------------------
-echo "------------------------Running tests-------------------"
-
+# Run test cases
 if !(make -C utest all); then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"

--- a/o/openblas/openblas_ubi_9.3.sh
+++ b/o/openblas/openblas_ubi_9.3.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/bash 
 # -----------------------------------------------------------------------------
 #
 # Package         : OpenBLAS
 # Version         : v0.3.32
 # Source repo     : https://github.com/OpenMathLib/OpenBLAS
-# Tested on       : UBI: 9.3
+# Tested on       : UBI: 9.6
 # Language        : C
 # Ci-Check    : True
 # Script License  : Apache License, Version 2 or later
@@ -12,7 +12,7 @@
 #
 # Disclaimer: This script has been tested in root mode on given
 # ==========  platform using the mentioned version of the package.
-#             It may not work as expected with newer versions of the
+#             it may not work as expected with newer versions of the
 #             package and/or distribution. In such case, please
 #             contact "Maintainer" of this script.
 #
@@ -27,6 +27,7 @@ PACKAGE_URL=https://github.com/OpenMathLib/OpenBLAS
 OPENBLAS_VERSION=${PACKAGE_VERSION}
 CURRENT_DIR=$(pwd)
 PACKAGE_DIR=OpenBLAS
+MAX_JOBS=${MAX_JOBS:-8}
 
 
 echo "------------------------Installing dependencies-------------------"
@@ -57,67 +58,71 @@ sed -i "s/{PACKAGE_VERSION}/$(echo $PACKAGE_VERSION | sed 's/^v//')/g" pyproject
 mkdir -p local/openblas
 PREFIX=local/openblas
 
-# Set build options
-declare -a build_opts
+export USE_OPENMP=1
+export USE_THREAD=1
+export NUM_THREADS=120
+export TARGET=POWER9
+export DYNAMIC_ARCH=1
+export INTERFACE64=0
+export BUILD_BFLOAT16=1
+export NO_AFFINITY=1
 
-# Fix ctest not automatically discovering tests
-LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
-
-# See this workaround: https://github.com/xianyi/OpenBLAS/issues/818#issuecomment-207365134
+# Fix flags
 export CF="${CFLAGS} -Wno-unused-parameter -Wno-old-style-declaration"
 unset CFLAGS
 
-export USE_OPENMP=1
-build_opts+=(USE_OPENMP=${USE_OPENMP})
-export PREFIX=${PREFIX}
+# Remove problematic linker flag if present
+LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-Wl,--gc-sections//g")
 
-# Handle Fortran flags
-if [ ! -z "$FFLAGS" ]; then
-    export FFLAGS="${FFLAGS/-fopenmp/ }"
-    export FFLAGS="${FFLAGS} -frecursive"
-    export LAPACK_FFLAGS="${FFLAGS}"
-fi
+# -----------------------------------------------------------------------------
+# Build
+# -----------------------------------------------------------------------------
+if ! make -j${MAX_JOBS} \
+    TARGET=${TARGET} \
+    BUILD_BFLOAT16=${BUILD_BFLOAT16} \
+    BINARY=64 \
+    USE_OPENMP=${USE_OPENMP} \
+    USE_THREAD=${USE_THREAD} \
+    NUM_THREADS=${NUM_THREADS} \
+    DYNAMIC_ARCH=${DYNAMIC_ARCH} \
+    INTERFACE64=${INTERFACE64} \
+    NO_AFFINITY=${NO_AFFINITY} \
+    CFLAGS="${CF}" ; then
 
-export PLATFORM=$(uname -m)
-build_opts+=(BINARY="64")
-build_opts+=(DYNAMIC_ARCH=1)
-build_opts+=(TARGET="POWER9")
-BUILD_BFLOAT16=1
-
-# Placeholder for future builds that may include ILP64 variants.
-build_opts+=(INTERFACE64=0)
-build_opts+=(SYMBOLSUFFIX="")
-
-# Build LAPACK
-build_opts+=(NO_LAPACK=0)
-
-# Enable threading and set the number of threads
-build_opts+=(USE_THREAD=1)
-build_opts+=(NUM_THREADS=120)
-
-# Disable CPU/memory affinity handling to avoid problems with NumPy and R
-build_opts+=(NO_AFFINITY=1)
-
-# Build OpenBLAS
-if ! (make -j8 ${build_opts[@]} CFLAGS="${CF}" FFLAGS="${FFLAGS}" prefix=${PREFIX}) ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
-    echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
     exit 1
 fi
 
+# -----------------------------------------------------------------------------
 # Install OpenBLAS
-CFLAGS="${CF}" FFLAGS="${FFLAGS}" make install PREFIX="${PREFIX}" ${build_opts[@]}
+# -----------------------------------------------------------------------------
+echo "------------------------Installing OpenBLAS-------------------"
 
-#install
-if ! (pip install . --no-build-isolation) ; then
+if ! make install PREFIX=${PREFIX} ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
-    echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
     exit 1
 fi
 
-# Run test cases
+# -----------------------------------------------------------------------------
+# Library path setup
+# -----------------------------------------------------------------------------
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PREFIX}/lib64:${PREFIX}/lib
+
+# -----------------------------------------------------------------------------
+# Python package install (from original script)
+# -----------------------------------------------------------------------------
+echo "------------------------Installing Python package-------------------"
+
+if ! pip install . --no-build-isolation ; then
+    echo "------------------$PACKAGE_NAME:Python_Install_fails-------------------------------------"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Run tests
+# -----------------------------------------------------------------------------
+echo "------------------------Running tests-------------------"
+
 if !(make -C utest all); then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
@@ -129,3 +134,5 @@ else
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
     exit 0
 fi
+
+# Made with Bob

--- a/o/openblas/openblas_ubi_9.3.sh
+++ b/o/openblas/openblas_ubi_9.3.sh
@@ -2,7 +2,7 @@
 # -----------------------------------------------------------------------------
 #
 # Package         : OpenBLAS
-# Version         : v0.3.29
+# Version         : v0.3.32
 # Source repo     : https://github.com/OpenMathLib/OpenBLAS
 # Tested on       : UBI: 9.3
 # Language        : C
@@ -37,6 +37,7 @@ yum install -y python python-pip python-devel  gcc-toolset-13 gcc-toolset-13-bin
 
 python -m pip install --upgrade pip wheel
 
+source /opt/rh/gcc-toolset-13/enable
 export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
 export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:$LD_LIBRARY_PATH
 gcc --version
@@ -51,8 +52,6 @@ git submodule update --init
 
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/o/openblas/pyproject.toml
 sed -i "s/{PACKAGE_VERSION}/$(echo $PACKAGE_VERSION | sed 's/^v//')/g" pyproject.toml
-sed -i 's/manylinux2014_ppc64le/linux_ppc64le/g' pyproject.toml
-echo "--------------------------replaced version and platform tag in pyproject.toml--------------------------"
 
 # Create the local directory structure expected by pyproject.toml
 mkdir -p local/openblas

--- a/o/openblas/openblas_ubi_9.3.sh
+++ b/o/openblas/openblas_ubi_9.3.sh
@@ -134,5 +134,3 @@ else
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
     exit 0
 fi
-
-# Made with Bob

--- a/o/openblas/pyproject.toml
+++ b/o/openblas/pyproject.toml
@@ -33,5 +33,5 @@ where = ["local"]
 openblas = ["lib/*", "include/*", "lib/pkgconfig/*", "lib/cmake/openblas/*"]
 
 [tool.distutils.bdist_wheel]
-plat-name = "manylinux2014_ppc64le"  # Explicitly set the platform tag
+plat-name = "linux_ppc64le"  # Explicitly set the platform tag
 universal = false  # Disable universal wheel (forces platform-specific build)


### PR DESCRIPTION
This commit fixes the OpenBLAS Python wheel build failure that occurred during
the pip install step with the error:
"error: error in 'egg_base' option: 'local' does not exist or is not a directory"

Changes made to o/openblas/openblas_ubi_9.3.sh:
- Added directory creation before PREFIX assignment (line 55-56):
   - Creates the 'local/openblas' directory structure that pyproject.toml expects
   - Ensures the directory exists before setuptools tries to locate packages
   - Resolves the "does not exist or is not a directory" error
- Change platform tag from manylinux2014_ppc64le to linux_ppc64le in pyproject.toml

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
