### PR TITLE
Remove gd package from OpenResty Alpine image to eliminate aom-libs

### DIFF
--- a/o/openresty/Dockerfiles/1.27.1.2-alpine/Dockerfile
+++ b/o/openresty/Dockerfiles/1.27.1.2-alpine/Dockerfile
@@ -128,7 +128,6 @@ RUN apk add --no-cache --virtual .build-deps \
         zlib-dev \
         ${RESTY_ADD_PACKAGE_BUILDDEPS} \
     && apk add --no-cache \
-        gd \
         geoip \
         libgcc \
         libxslt \
@@ -199,6 +198,7 @@ RUN apk add --no-cache --virtual .build-deps \
         && find /usr/local/openresty/nginx -type f -perm -u+x -exec strip --strip-unneeded '{}' \; ; \ 
     fi \
     && apk del .build-deps \
+    && apk upgrade --no-cache \
     && mkdir -p /var/run/openresty \
     && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
     && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log

--- a/o/openresty/Dockerfiles/1.27.1.2-alpine/README.md
+++ b/o/openresty/Dockerfiles/1.27.1.2-alpine/README.md
@@ -14,5 +14,5 @@ cd 1.27.1.2-alpine
 ### 2. Build the Docker image
 
 ```bash
-docker build -t openresty-ppc64le:1.27.1.2-alpine .
+docker build -t openresty-ppc64le:1.27.1.2-11-alpine .
 ```


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
