### PR TITLE
[ODH] Created build_script and build_info for milvus-lite-v2.5.1

### DIFF
--- a/m/milvus-lite/build_info.json
+++ b/m/milvus-lite/build_info.json
@@ -1,19 +1,22 @@
 {
-	"maintainer": "vikram9491",
-	"package_name": "milvus-lite",
-	"github_url": "https://github.com/milvus-io/milvus-lite",
-	"version": "v2.5.0",
-	"default_branch": "main",
-	"build_script": "milvus-lite_2.5.0_ubi_9.6.sh",
-	"package_dir": "m/milvus-lite",
-	"docker_build": false,
-	"validate_build_script": true,
-	"wheel_build" : true,
-	"use_non_root_user": false,
-	"v2.4.12": {
-     	"build_script": "milvus-lite_ubi_9.3.sh"
-      	},
-  	"*": {
-    	"build_script":"milvus-lite_2.5.0_ubi_9.6.sh"
- 	 }
+    "maintainer": "puneetsharma21",
+    "package_name": "milvus-lite",
+    "github_url": "https://github.com/milvus-io/milvus-lite",
+    "version": "v2.5.1",
+    "default_branch": "main",
+    "build_script": "milvus-lite_2.5.1_ubi_9.6.sh",
+    "package_dir": "m/milvus-lite",
+    "docker_build": false,
+    "validate_build_script": true,
+    "wheel_build" : true,
+    "use_non_root_user": false,
+    "v2.4.12": {
+        "build_script": "milvus-lite_ubi_9.3.sh"
+        },
+    "v2.5.0": {
+        "build_script":"milvus-lite_2.5.0_ubi_9.6.sh"
+        },
+    "v2.5.1": {
+        "build_script":"milvus-lite_2.5.1_ubi_9.6.sh"
+        }
 }

--- a/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
+++ b/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
@@ -1,0 +1,160 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : milvus-lite
+# Version       : 2.5.1
+# Source repo   : https://github.com/milvus-io/milvus-lite
+# Tested on     : UBI:9.6
+# Language      : Python
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Puneet Sharma <Puneet.Sharma21@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ========== platform using the mentioned version of the package.
+# It may not work as expected with newer versions of the
+# package and/or distribution. In such case, please
+# contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+PACKAGE_URL="https://github.com/milvus-io/milvus-lite"
+PACKAGE_NAME=milvus-lite
+PACKAGE_DIR=milvus-lite/python
+PACKAGE_VERSION=${1:-v2.5.1}
+PWDIR=$(pwd)
+
+# 0. Install system tools
+yum install -y git gcc-c++ gcc wget make python3.12 yum-utils \
+               apr-devel perl openssl-devel automake autoconf libtool cmake \
+               cargo libstdc++-static libaio libuuid-devel ncurses-devel \
+               libtool m4 autoconf automake ninja-build zlib-devel \
+               libffi-devel scl-utils xz patch \
+               python3.12-devel python3.12-pip
+
+yum remove -y gcc-toolset-13 || true
+gcc --version
+echo "Using system GCC for milvus-lite build"
+
+echo "Building OpenBLAS from source..."
+export MAX_JOBS=$(nproc)
+
+git clone https://github.com/OpenMathLib/OpenBLAS
+cd OpenBLAS
+git checkout v0.3.32
+
+make -j${MAX_JOBS} \
+    TARGET=POWER9 \
+    BUILD_BFLOAT16=1 \
+    BINARY=64 \
+    USE_OPENMP=1 \
+    USE_THREAD=1 \
+    NUM_THREADS=120 \
+    DYNAMIC_ARCH=1 \
+    INTERFACE64=0
+
+make install PREFIX=/usr/local
+
+# Configure linker paths
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LIBRARY_PATH
+export CPATH=/usr/local/include:$CPATH
+
+echo "/usr/local/lib" >> /etc/ld.so.conf.d/openblas.conf
+echo "/usr/local/lib64" >> /etc/ld.so.conf.d/openblas.conf
+ldconfig
+
+cd ..
+
+# -----------------------------------------------------------------------------
+# 1. Set up Conan (for Milvus-Lite’s C++ deps)
+# -----------------------------------------------------------------------------
+python3.12 -m pip install --upgrade pip wheel setuptools conan==1.64.1
+
+# -----------------------------------------------------------------------------
+# 2. Build & install Texinfo (required by milvus-lite)
+# -----------------------------------------------------------------------------
+TEX_VER=7.1
+echo "Downloading texinfo..."
+for url in \
+  https://mirrors.kernel.org/gnu/texinfo/texinfo-${TEX_VER}.tar.xz \
+  https://ftpmirror.gnu.org/texinfo/texinfo-${TEX_VER}.tar.xz \
+  https://ftp.gnu.org/gnu/texinfo/texinfo-${TEX_VER}.tar.xz
+do
+  wget "$url" && break
+done
+tar -xf "texinfo-${TEX_VER}.tar.xz"
+pushd "texinfo-${TEX_VER}"
+  ./configure && make -j2 && make install
+popd
+rm -rf "texinfo-${TEX_VER}"*
+
+# -----------------------------------------------------------------------------
+# 3. Build CMake 3.30.5 and register as a Conan package
+# -----------------------------------------------------------------------------
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+   | sh -s -- --default-toolchain stable -y
+source "$HOME/.cargo/env"
+rustc --version
+
+###############################################################################
+# 4. Build & register CMake 3.30.5 as a Conan application package
+###############################################################################
+CMAKE_VERSION=3.30.5
+mkdir -p "${PWDIR}/workspace"
+pushd "${PWDIR}/workspace"
+    if [[ ! -d "cmake-${CMAKE_VERSION}" ]]; then
+        wget -c "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz"
+        tar -xzf "cmake-${CMAKE_VERSION}.tar.gz"
+    fi
+    rm -rf cmake-${CMAKE_VERSION}.tar.gz
+    cd "cmake-${CMAKE_VERSION}"
+    ./bootstrap --prefix=/usr/local/cmake --parallel=2 \
+                -- -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_USE_OPENSSL=ON
+    make -j2
+    make install
+popd
+export PATH=/usr/local/cmake/bin:$PATH
+cmake --version
+ echo "cmake installed ...."
+CMAKE_REQUIRED_VERSION=3.30.5
+create_cmake_conanfile()
+{
+   touch /usr/local/cmake/conanfile.py
+    cat <<EOT >> /usr/local/cmake/conanfile.py
+from conans import ConanFile, tools
+class CmakeConan(ConanFile):
+  name = "cmake"
+  package_type = "application"
+  version = "${CMAKE_REQUIRED_VERSION}"
+  description = "CMake, the cross-platform, open-source build system."
+  homepage = "https://github.com/Kitware/CMake"
+  license = "BSD-3-Clause"
+  topics = ("build", "installer")
+  settings = "os", "arch"
+  def package(self):
+    self.copy("*")
+  def package_info(self):
+    self.cpp_info.libs = tools.collect_libs(self)
+EOT
+}
+pushd /usr/local/cmake
+    create_cmake_conanfile
+    conan export-pkg . cmake/3.30.5@ -s os=Linux -s arch=$(uname -m) -f
+popd
+echo " exported completed successfully...."
+# -----------------------------------------------------------------------------
+# 5. Clone, patch & build Milvus-Lite
+# -----------------------------------------------------------------------------
+git clone "$PACKAGE_URL"
+pushd milvus-lite
+  git checkout "${PACKAGE_VERSION}"
+  git submodule update --init --recursive
+  # Build Python wheel and install
+  pushd python
+    python3.12 -m pip install -r requirements.txt build
+    python3.12 setup.py install
+  popd
+popd
+
+echo "==========  All builds & installs completed successfully!  =========="
+exit 0

--- a/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
+++ b/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
@@ -28,7 +28,7 @@ yum install -y git gcc-c++ gcc wget make python3.12 yum-utils \
                apr-devel perl openssl-devel automake autoconf libtool cmake \
                cargo libstdc++-static libaio libuuid-devel ncurses-devel \
                libtool m4 autoconf automake ninja-build zlib-devel \
-               libffi-devel scl-utils xz patch \
+               libffi-devel scl-utils openblas-devel xz patch \
                python3.12-devel python3.12-pip
 
 yum remove -y gcc-toolset-13 || true


### PR DESCRIPTION
log :
```
running build
running build_py
copying src/milvus_lite/__init__.py -> build/lib/milvus_lite
copying src/milvus_lite/cmdline.py -> build/lib/milvus_lite
copying src/milvus_lite/server.py -> build/lib/milvus_lite
copying src/milvus_lite/server_manager.py -> build/lib/milvus_lite
running egg_info
writing src/milvus_lite.egg-info/PKG-INFO
writing dependency_links to src/milvus_lite.egg-info/dependency_links.txt
writing entry points to src/milvus_lite.egg-info/entry_points.txt
writing requirements to src/milvus_lite.egg-info/requires.txt
writing top-level names to src/milvus_lite.egg-info/top_level.txt
reading manifest file 'src/milvus_lite.egg-info/SOURCES.txt'
writing manifest file 'src/milvus_lite.egg-info/SOURCES.txt'
installing to build/bdist.linux-ppc64le/wheel
running install
running install_lib
copying build/lib/milvus_lite/__init__.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/cmdline.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/server.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/server_manager.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
running install_egg_info
Copying src/milvus_lite.egg-info to build/bdist.linux-ppc64le/wheel/./milvus_lite-2.5.1-py3.12.egg-info
running install_scripts
creating build/bdist.linux-ppc64le/wheel/milvus_lite-2.5.1.dist-info/WHEEL
creating '/build-scripts/.tmp-r3c4npf7/milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl' and adding 'build/bdist.linux-ppc64le/wheel' to it
adding 'milvus_lite/__init__.py'
adding 'milvus_lite/cmdline.py'
adding 'milvus_lite/server.py'
adding 'milvus_lite/server_manager.py'
adding 'milvus_lite/lib/libdouble-conversion.so.3'
adding 'milvus_lite/lib/libgcc_s.so.1'
adding 'milvus_lite/lib/libgflags_nothreads.so.2.2'
adding 'milvus_lite/lib/libglog.so.1'
adding 'milvus_lite/lib/libgomp.so.1'
adding 'milvus_lite/lib/libknowhere.so'
adding 'milvus_lite/lib/libm.so.6'
adding 'milvus_lite/lib/libopenblas.so.0'
adding 'milvus_lite/lib/libtbb.so.12'
adding 'milvus_lite/lib/milvus'
adding 'milvus_lite-2.5.1.dist-info/METADATA'
adding 'milvus_lite-2.5.1.dist-info/WHEEL'
adding 'milvus_lite-2.5.1.dist-info/entry_points.txt'
adding 'milvus_lite-2.5.1.dist-info/top_level.txt'
adding 'milvus_lite-2.5.1.dist-info/RECORD'
removing build/bdist.linux-ppc64le/wheel
Successfully built milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl
=============== Modifying Metadata file ==================
Added IBM classifier to milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl
```