### PR TITLE
Docling parse

### DIFF
--- a/d/docling-parse/docling-parse_ubi_9.6.sh
+++ b/d/docling-parse/docling-parse_ubi_9.6.sh
@@ -23,7 +23,7 @@ set -e
 # Variables
 PACKAGE_DIR="docling-parse"
 PACKAGE_NAME="docling-parse"
-PACKAGE_VERSION="${1:-v4.7.1}"
+PACKAGE_VERSION="${1:-v5.11.0}"
 PACKAGE_URL="https://github.com/docling-project/docling-parse.git"
 
 OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)

--- a/d/docling-parse/docling-parse_ubi_9.6.sh
+++ b/d/docling-parse/docling-parse_ubi_9.6.sh
@@ -33,6 +33,7 @@ SOURCE=Github
 echo "Installing required packages..."
 yum install -y git wget gcc gcc-c++ python3.12-devel python3.12-pip zlib zlib-devel libjpeg-devel libjpeg-turbo libjpeg-turbo-devel freetype-devel
 python3.12 -m pip install build pytest wheel
+python3.12 -m pip install huggingface-hub
 
 export PATH=$PATH:/usr/local/bin/
 export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

Docling-parse is no longer supported for Python version 3.9 and lower. 
Added missing packages `huggingface-hub`

Fixing for error log - https://github.com/ppc64le/build-scripts/actions/runs/25753080788
