### PR TITLE
Update pyproject.toml to include project metadata

### DIFF
--- a/a/ansible-hub-ui/ansible-hub-ui_ubi_9.6.sh
+++ b/a/ansible-hub-ui/ansible-hub-ui_ubi_9.6.sh
@@ -40,6 +40,13 @@ git checkout $PACKAGE_VERSION
 sed -i '/"@ls-lint\/ls-lint"/d' package.json
 sed -i '/"lint:ls": "ls-lint"/d' package.json
 
+# Fix pyproject.toml: The original file only contains [tool.towncrier] section for changelog management.
+# Python's build system requires a [project] section with 'name' and 'version' metadata to generate
+# a proper wheel file. Without this, the build produces 'unknown-0.0.0-py3-none-any.whl'.
+# This sed command inserts the [project] section before [tool.towncrier], preserving the original content.
+# This ensures any downstream wheel building process will have the correct package metadata.
+sed -i '/^\[tool\.towncrier\]/i [project]\nname = "ansible-hub-ui"\nversion = "'"$PACKAGE_VERSION"'"\n' pyproject.toml
+
 #Install dependencies
 if ! npm install ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"


### PR DESCRIPTION
**Wheel name is fixed**
- ✅ Wheel now generates as `ansible_hub_ui-4.9.2-py3-none-any.whl` with correct package name and version.
- Added sed command to insert [project] section in pyproject.toml
- Includes package name "ansible-hub-ui" and version from PACKAGE_VERSION variable
- Prevents generation of 'unknown-0.0.0-py3-none-any.whl' files

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
