### PR TITLE
Remove support of python3.9 from pr-build.yaml

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -180,68 +180,6 @@ jobs:
 # ===================== WHEEL JOBS =====================
 
 
-  wheel_build_py39:
-    needs: build_info
-    if: ${{ success() }}
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04-ppc64le-p10' || inputs.large-runner }}
-    continue-on-error: true
-    env:
-      GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
-      GHA_CURRENCY_SERVICE_ID: ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
-      PYTHON_VERSION: "3.9"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt update -y
-
-      - name: Download package-cache from previous step
-        uses: actions/download-artifact@v7
-        with:
-          name: package-cache
-
-      - name: Extract package cache
-        run: tar -xzf package-cache.tar.gz
-
-      - name: Run build_wheels.sh
-        run: |
-          ls
-          echo "---------------------updated cache-----------------------"
-          ls package-cache
-
-          chmod +x package-cache/variable.sh
-          chmod +x package-cache/scanner-env.sh
-          source package-cache/variable.sh
-          source package-cache/scanner-env.sh
-
-          # CONTROL FLAG HERE
-          if [ "$WHEEL_BUILD" != "true" ]; then
-            echo "Skipping wheel build as WHEEL_BUILD=false"
-            exit 0
-          fi
-
-          # Check if any .sh build script is modified in this package
-          BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
-
-          if [[ -z "$BUILD_SCRIPT_CHANGED" ]]; then
-            echo "Skipping wheel build as no .sh build script changes detected"
-            exit 0
-          fi
-
-          chmod +x ./gha-script/build_wheels.sh
-          bash ./gha-script/build_wheels.sh
-
-          echo "===========after execution =================="
-          sudo apt update -y
-          sudo lsb_release -a 2>/dev/null || echo "lsb_release not available"
-          sudo uname -a
-
 
   wheel_build_py310:
     needs: build_info


### PR DESCRIPTION
Removed the wheel_build_py39 job from the CI workflow.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
