### PR TITLE
Update milvus-lite build script

### DIFF
--- a/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
+++ b/m/milvus-lite/milvus-lite_2.5.1_ubi_9.6.sh
@@ -29,7 +29,7 @@ yum install -y git gcc-c++ gcc wget make python3.12 yum-utils \
                cargo libstdc++-static libaio libuuid-devel ncurses-devel \
                libtool m4 autoconf automake ninja-build zlib-devel \
                libffi-devel scl-utils openblas-devel xz patch \
-               python3.12-devel python3.12-pip
+               python3.12-devel python3.12-pip sqlite sqlite-devel
 
 yum remove -y gcc-toolset-13 || true
 gcc --version
@@ -142,6 +142,7 @@ pushd /usr/local/cmake
     conan export-pkg . cmake/3.30.5@ -s os=Linux -s arch=$(uname -m) -f
 popd
 echo " exported completed successfully...."
+
 # -----------------------------------------------------------------------------
 # 5. Clone, patch & build Milvus-Lite
 # -----------------------------------------------------------------------------
@@ -157,4 +158,25 @@ pushd milvus-lite
 popd
 
 echo "==========  All builds & installs completed successfully!  =========="
+
+# -----------------------------------------------------------------------------
+# thrift Conan recipe to use HTTPS instead of HTTP
+# -----------------------------------------------------------------------------
+
+THRIFT_VERSION=0.20.0
+
+# Download only recipe metadata
+conan download thrift/${THRIFT_VERSION}@
+
+THRIFT_EXPORT_DIR=$(find /root/.conan/data/thrift/${THRIFT_VERSION} -type f -name conanfile.py | head -1 | xargs dirname)
+
+echo "Thrift export dir: ${THRIFT_EXPORT_DIR}"
+
+# Replace HTTP with HTTPS
+find ${THRIFT_EXPORT_DIR} -type f | xargs sed -i \
+'s|http://archive.apache.org/dist/thrift/|https://archive.apache.org/dist/thrift/|g'
+
+echo "Patched thrift Conan recipe to HTTPS"
+cd $PWDIR
+
 exit 0


### PR DESCRIPTION
build log :
```
[100%] Built target milvus
gmake[1]: Leaving directory '/build-scripts/milvus-lite/python/build/bdist.linux-ppc64le/build_milvus'
/usr/local/cmake/bin/cmake -E cmake_progress_start /build-scripts/milvus-lite/python/build/bdist.linux-ppc64le/build_milvus/CMakeFiles 0
running build
running build_py
copying src/milvus_lite/__init__.py -> build/lib/milvus_lite
copying src/milvus_lite/cmdline.py -> build/lib/milvus_lite
copying src/milvus_lite/server.py -> build/lib/milvus_lite
copying src/milvus_lite/server_manager.py -> build/lib/milvus_lite
running egg_info
writing src/milvus_lite.egg-info/PKG-INFO
writing dependency_links to src/milvus_lite.egg-info/dependency_links.txt
writing entry points to src/milvus_lite.egg-info/entry_points.txt
writing requirements to src/milvus_lite.egg-info/requires.txt
writing top-level names to src/milvus_lite.egg-info/top_level.txt
reading manifest file 'src/milvus_lite.egg-info/SOURCES.txt'
writing manifest file 'src/milvus_lite.egg-info/SOURCES.txt'
installing to build/bdist.linux-ppc64le/wheel
running install
running install_lib
copying build/lib/milvus_lite/__init__.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/cmdline.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/server.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
copying build/lib/milvus_lite/server_manager.py -> build/bdist.linux-ppc64le/wheel/./milvus_lite
running install_egg_info
Copying src/milvus_lite.egg-info to build/bdist.linux-ppc64le/wheel/./milvus_lite-2.5.1-py3.12.egg-info
running install_scripts
creating build/bdist.linux-ppc64le/wheel/milvus_lite-2.5.1.dist-info/WHEEL
creating '/build-scripts/.tmp-2d2wynh3/milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl' and adding 'build/bdist.linux-ppc64le/wheel' to it
adding 'milvus_lite/__init__.py'
adding 'milvus_lite/cmdline.py'
adding 'milvus_lite/server.py'
adding 'milvus_lite/server_manager.py'
adding 'milvus_lite/lib/libdouble-conversion.so.3'
adding 'milvus_lite/lib/libgcc_s.so.1'
adding 'milvus_lite/lib/libgflags_nothreads.so.2.2'
adding 'milvus_lite/lib/libglog.so.1'
adding 'milvus_lite/lib/libgomp.so.1'
adding 'milvus_lite/lib/libknowhere.so'
adding 'milvus_lite/lib/libm.so.6'
adding 'milvus_lite/lib/libopenblas.so.0'
adding 'milvus_lite/lib/libtbb.so.12'
adding 'milvus_lite/lib/milvus'
adding 'milvus_lite-2.5.1.dist-info/METADATA'
adding 'milvus_lite-2.5.1.dist-info/WHEEL'
adding 'milvus_lite-2.5.1.dist-info/entry_points.txt'
adding 'milvus_lite-2.5.1.dist-info/top_level.txt'
adding 'milvus_lite-2.5.1.dist-info/RECORD'
removing build/bdist.linux-ppc64le/wheel
Successfully built milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl
=============== Modifying Metadata file ==================
Added IBM classifier to milvus_lite-2.5.1-py3-none-manylinux2014_ppc64le.whl
```