### PR TITLE
Vllm changes

### DIFF
--- a/v/vllm/vllm_v0.11.1_ubi_9.5.sh
+++ b/v/vllm/vllm_v0.11.1_ubi_9.5.sh
@@ -318,6 +318,7 @@ python3.12 -m pip install xgrammar
 export VLLM_TARGET_DEVICE=cpu
 export MAX_JOBS=$(nproc)
 
+export SETUPTOOLS_SCM_PRETEND_VERSION=${PACKAGE_VERSION#v}
 python3.12 setup.py install
 
 python3.12 setup.py bdist_wheel --dist-dir="${CURRENT_DIR}"

--- a/v/vllm/vllm_v0.15.1_ubi_9.5.sh
+++ b/v/vllm/vllm_v0.15.1_ubi_9.5.sh
@@ -407,6 +407,7 @@ python3.12 -m pip install xgrammar
 export VLLM_TARGET_DEVICE=cpu
 export MAX_JOBS=$(nproc)
 
+export SETUPTOOLS_SCM_PRETEND_VERSION=${PACKAGE_VERSION#v}
 python3.12 setup.py install
 
 python3.12 setup.py bdist_wheel --dist-dir="${CURRENT_DIR}"
@@ -424,6 +425,7 @@ echo "==================================================================="
 echo "Running basic offline inference example..."
 
 export VLLM_CPU_KVCACHE_SPACE=4
+export LD_PRELOAD=$(find /opt/rh/gcc-toolset-13/root/usr/lib64/ -name "libgomp.so*" | head -n 1)
 
 if ! python3.12 ${PACKAGE_DIR}/examples/offline_inference/basic/basic.py; then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"

--- a/v/vllm/vllm_v0.16.0_ubi_9.6.sh
+++ b/v/vllm/vllm_v0.16.0_ubi_9.6.sh
@@ -436,6 +436,7 @@ echo "==================================================================="
 echo "Running basic offline inference example..."
 
 export VLLM_CPU_KVCACHE_SPACE=4
+export LD_PRELOAD=$(find /opt/rh/gcc-toolset-13/root/usr/lib64/ -name "libgomp.so*" | head -n 1)
 
 if ! python3.12 ${PACKAGE_DIR}/examples/offline_inference/basic/basic.py; then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"

--- a/v/vllm/vllm_v0.21.0_ubi_9.5.sh
+++ b/v/vllm/vllm_v0.21.0_ubi_9.5.sh
@@ -218,6 +218,7 @@ echo "==================================================================="
 echo "-------------------- Testing installed vLLM ------------------------"
 
 export VLLM_CPU_KVCACHE_SPACE=4
+export LD_PRELOAD=$(find /opt/rh/gcc-toolset-13/root/usr/lib64/ -name "libgomp.so*" | head -n 1)
 
 if ! python3.12 ${PACKAGE_DIR}/examples/basic/offline_inference/basic.py; then
   echo "INSTALL SUCCESS BUT TEST FAILED"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


Fixes issue https://github.ibm.com/ppc64le-automation/python-ecosystem/issues/1113

and below error:

```
2026-06-02T07:46:42.6554248Z ===================================================================
2026-06-02T07:46:42.6555580Z                vLLM WHEEL BUILT SUCCESSFULLY (v0.15.1)
2026-06-02T07:46:42.6556892Z ===================================================================
2026-06-02T07:46:42.6558201Z Running basic offline inference example...
2026-06-02T07:46:42.6560588Z INFO 06-02 07:46:25 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
2026-06-02T07:46:42.6563801Z INFO 06-02 07:46:27 [utils.py:223] non-default args: {'disable_log_stats': True, 'model': 'facebook/opt-125m'}
2026-06-02T07:46:42.6566277Z INFO 06-02 07:46:34 [model.py:529] Resolved architecture: OPTForCausalLM
2026-06-02T07:46:42.6569135Z WARNING 06-02 07:46:34 [model.py:1821] Your device 'cpu' doesn't support torch.float16. Falling back to torch.bfloat16 for compatibility.
2026-06-02T07:46:42.6572130Z WARNING 06-02 07:46:34 [model.py:1874] Casting torch.float16 to torch.bfloat16.
2026-06-02T07:46:42.6574001Z INFO 06-02 07:46:34 [model.py:1549] Using max model len 2048
2026-06-02T07:46:42.6576600Z INFO 06-02 07:46:34 [arg_utils.py:1993] Chunked prefill is not supported for POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
2026-06-02T07:46:42.6580200Z INFO 06-02 07:46:34 [arg_utils.py:1999] Prefix caching is not supported for POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
2026-06-02T07:46:42.6582894Z INFO 06-02 07:46:34 [vllm.py:689] Asynchronous scheduling is enabled.
2026-06-02T07:46:42.6585618Z INFO 06-02 07:46:39 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
2026-06-02T07:46:50.8628778Z (EngineCore_DP0 pid=39062) INFO 06-02 07:46:40 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='facebook/opt-125m', speculative_config=None, tokenizer='facebook/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=facebook/opt-125m, enable_prefix_caching=False, enable_chunked_prefill=False, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.DYNAMO_TRACE_ONCE: 2>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_split_points': [4096], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'dce': True, 'size_asserts': False, 'nan_asserts': False, 'epilogue_fusion': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
2026-06-02T07:46:50.8667403Z (EngineCore_DP0 pid=39062) Process EngineCore_DP0:
2026-06-02T07:46:50.8669335Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006] EngineCore failed to start.
2026-06-02T07:46:50.8671866Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006] Traceback (most recent call last):
2026-06-02T07:46:50.8676571Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 996, in run_engine_core
2026-06-02T07:46:50.8681537Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
2026-06-02T07:46:50.8685050Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8689694Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 740, in __init__
2026-06-02T07:46:50.8694207Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     super().__init__(
2026-06-02T07:46:50.8698433Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 106, in __init__
2026-06-02T07:46:50.8703019Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     self.model_executor = executor_class(vllm_config)
2026-06-02T07:46:50.8706031Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8710604Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/executor/abstract.py", line 103, in __init__
2026-06-02T07:46:50.8715005Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     self._init_executor()
2026-06-02T07:46:50.8719545Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/executor/uniproc_executor.py", line 47, in _init_executor
2026-06-02T07:46:50.8724220Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     self.driver_worker.init_device()
2026-06-02T07:46:50.8728817Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/worker_base.py", line 322, in init_device
2026-06-02T07:46:50.8733650Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     self.worker.init_device()  # type: ignore
2026-06-02T07:46:50.8736334Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     ^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8740691Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/cpu_worker.py", line 61, in init_device
2026-06-02T07:46:50.8745370Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     self.local_omp_cpuid = self._get_autobind_cpu_ids(
2026-06-02T07:46:50.8748341Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8753116Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/cpu_worker.py", line 192, in _get_autobind_cpu_ids
2026-06-02T07:46:50.8757998Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]     assert len(logical_cpu_list) > reserve_cpu_num, (
2026-06-02T07:46:50.8761012Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8764158Z (EngineCore_DP0 pid=39062) ERROR 06-02 07:46:41 [core.py:1006] AssertionError: VLLM_CPU_NUM_OF_RESERVED_CPU (0) should less than 0.
2026-06-02T07:46:50.8766819Z (EngineCore_DP0 pid=39062) Traceback (most recent call last):
2026-06-02T07:46:50.8769244Z (EngineCore_DP0 pid=39062)   File "/usr/lib64/python3.11/multiprocessing/process.py", line 314, in _bootstrap
2026-06-02T07:46:50.8771536Z (EngineCore_DP0 pid=39062)     self.run()
2026-06-02T07:46:50.8773563Z (EngineCore_DP0 pid=39062)   File "/usr/lib64/python3.11/multiprocessing/process.py", line 108, in run
2026-06-02T07:46:50.8776046Z (EngineCore_DP0 pid=39062)     self._target(*self._args, **self._kwargs)
2026-06-02T07:46:50.8779937Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 1010, in run_engine_core
2026-06-02T07:46:50.8783358Z (EngineCore_DP0 pid=39062)     raise e
2026-06-02T07:46:50.8786636Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 996, in run_engine_core
2026-06-02T07:46:50.8791415Z (EngineCore_DP0 pid=39062)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
2026-06-02T07:46:50.8794079Z (EngineCore_DP0 pid=39062)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8797877Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 740, in __init__
2026-06-02T07:46:50.8801300Z (EngineCore_DP0 pid=39062)     super().__init__(
2026-06-02T07:46:50.8805007Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core.py", line 106, in __init__
2026-06-02T07:46:50.8808819Z (EngineCore_DP0 pid=39062)     self.model_executor = executor_class(vllm_config)
2026-06-02T07:46:50.8810919Z (EngineCore_DP0 pid=39062)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8814654Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/executor/abstract.py", line 103, in __init__
2026-06-02T07:46:50.8818107Z (EngineCore_DP0 pid=39062)     self._init_executor()
2026-06-02T07:46:50.8821830Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/executor/uniproc_executor.py", line 47, in _init_executor
2026-06-02T07:46:50.8825845Z (EngineCore_DP0 pid=39062)     self.driver_worker.init_device()
2026-06-02T07:46:50.8829541Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/worker_base.py", line 322, in init_device
2026-06-02T07:46:50.8833433Z (EngineCore_DP0 pid=39062)     self.worker.init_device()  # type: ignore
2026-06-02T07:46:50.8835216Z (EngineCore_DP0 pid=39062)     ^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8838733Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/cpu_worker.py", line 61, in init_device
2026-06-02T07:46:50.8842645Z (EngineCore_DP0 pid=39062)     self.local_omp_cpuid = self._get_autobind_cpu_ids(
2026-06-02T07:46:50.8844802Z (EngineCore_DP0 pid=39062)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8848876Z (EngineCore_DP0 pid=39062)   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/worker/cpu_worker.py", line 192, in _get_autobind_cpu_ids
2026-06-02T07:46:50.8852942Z (EngineCore_DP0 pid=39062)     assert len(logical_cpu_list) > reserve_cpu_num, (
2026-06-02T07:46:50.8855021Z (EngineCore_DP0 pid=39062)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8857345Z (EngineCore_DP0 pid=39062) AssertionError: VLLM_CPU_NUM_OF_RESERVED_CPU (0) should less than 0.
2026-06-02T07:46:50.8859306Z Traceback (most recent call last):
2026-06-02T07:46:50.8861113Z   File "/home/tester/vllm/examples/offline_inference/basic/basic.py", line 35, in <module>
2026-06-02T07:46:50.8862949Z     main()
2026-06-02T07:46:50.8864378Z   File "/home/tester/vllm/examples/offline_inference/basic/basic.py", line 19, in main
2026-06-02T07:46:50.8866352Z     llm = LLM(model="facebook/opt-125m")
2026-06-02T07:46:50.8867467Z           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8870417Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/entrypoints/llm.py", line 346, in __init__
2026-06-02T07:46:50.8873366Z     self.llm_engine = LLMEngine.from_engine_args(
2026-06-02T07:46:50.8874634Z                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8877642Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/llm_engine.py", line 174, in from_engine_args
2026-06-02T07:46:50.8880590Z     return cls(
2026-06-02T07:46:50.8881344Z            ^^^^
2026-06-02T07:46:50.8883914Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/llm_engine.py", line 108, in __init__
2026-06-02T07:46:50.8886980Z     self.engine_core = EngineCoreClient.make_client(
2026-06-02T07:46:50.8888396Z                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8891422Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core_client.py", line 95, in make_client
2026-06-02T07:46:50.8894745Z     return SyncMPClient(vllm_config, executor_class, log_stats)
2026-06-02T07:46:50.8896324Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-02T07:46:50.8899325Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core_client.py", line 659, in __init__
2026-06-02T07:46:50.8902201Z     super().__init__(
2026-06-02T07:46:50.8904897Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/core_client.py", line 490, in __init__
2026-06-02T07:46:50.8908208Z     with launch_core_engines(vllm_config, executor_class, log_stats) as (
2026-06-02T07:46:50.8910167Z   File "/usr/lib64/python3.11/contextlib.py", line 144, in __exit__
2026-06-02T07:46:50.8911588Z     next(self.gen)
2026-06-02T07:46:50.8914418Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/utils.py", line 925, in launch_core_engines
2026-06-02T07:46:50.8917366Z     wait_for_engine_startup(
2026-06-02T07:46:50.8920351Z   File "/home/tester/pyvenv_3.11/lib64/python3.11/site-packages/vllm-0.16.0+cpu-py3.11-linux-ppc64le.egg/vllm/v1/engine/utils.py", line 984, in wait_for_engine_startup
2026-06-02T07:46:50.8923382Z     raise RuntimeError(
2026-06-02T07:46:50.8925181Z RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
2026-06-02T07:46:50.8927559Z ------------------vllm:install_success_but_test_fails---------------------
2026-06-02T07:46:50.8929250Z https://github.com/vllm-project/vllm.git vllm
2026-06-02T07:46:50.8931525Z vllm  |  https://github.com/vllm-project/vllm.git | v0.16.0 |  | GitHub | Fail |  Install_success_but_test_Fails
2026-06-02T07:46:50.9174956Z Traceback (most recent call last):
2026-06-02T07:46:50.9177320Z   File "/tmp/_actions-runner-working-dir/build-scripts/build-scripts/gha-script/build_wheels.py", line 75, in <module>
2026-06-02T07:46:50.9196856Z     trigger_build_wheel(sys.argv[1],sys.argv[2],sys.argv[3],sys.argv[4],sys.argv[5],sys.argv[6])
2026-06-02T07:46:50.9200327Z   File "/tmp/_actions-runner-working-dir/build-scripts/build-scripts/gha-script/build_wheels.py", line 69, in trigger_build_wheel
2026-06-02T07:46:50.9203290Z     raise Exception(f"Build script validation failed for {file_name}!")
2026-06-02T07:46:50.9205400Z Exception: Build script validation failed for v/vllm/vllm_v0.16.0_ubi_9.6.sh!
2026-06-02T07:46:50.9453357Z Wheel build failed for v/vllm/vllm_v0.16.0_ubi_9.6.sh v0.16.0 
2026-06-02T07:46:50.9456711Z *************************************************************************************
2026-06-02T07:46:50.9474051Z ##[error]Process completed with exit code 1.
2026-06-02T07:46:50.9730576Z Post job cleanup.
2026-06-02T07:46:51.0709736Z [command]/usr/bin/git version
2026-06-02T07:46:51.0754154Z git version 2.54.0
2026-06-02T07:46:51.0797583Z Temporarily overriding HOME='/tmp/_actions-runner-working-dir/_temp/a286638d-4dbc-4771-88df-aa4b9f8966cb' before making global git config changes
2026-06-02T07:46:51.0801076Z Adding repository directory to the temporary git global config as a safe directory
2026-06-02T07:46:51.0804701Z [command]/usr/bin/git config --global --add safe.directory /tmp/_actions-runner-working-dir/build-scripts/build-scripts
2026-06-02T07:46:51.0848169Z Removing SSH command configuration
2026-06-02T07:46:51.0850496Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-06-02T07:46:51.0880014Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-06-02T07:46:51.1093598Z Removing HTTP extra header
2026-06-02T07:46:51.1100124Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-06-02T07:46:51.1131021Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-06-02T07:46:51.1292707Z Removing includeIf entries pointing to credentials config files
2026-06-02T07:46:51.1299069Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-06-02T07:46:51.1317091Z includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git.path
2026-06-02T07:46:51.1320078Z includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git/worktrees/*.path
2026-06-02T07:46:51.1334039Z includeif.gitdir:/github/workspace/.git.path
2026-06-02T07:46:51.1335590Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-06-02T07:46:51.1339750Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git.path
2026-06-02T07:46:51.1349279Z /tmp/_actions-runner-working-dir/_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1361613Z [command]/usr/bin/git config --local --unset includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git.path /tmp/_actions-runner-working-dir/_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1400778Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git/worktrees/*.path
2026-06-02T07:46:51.1417456Z /tmp/_actions-runner-working-dir/_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1428888Z [command]/usr/bin/git config --local --unset includeif.gitdir:/tmp/_actions-runner-working-dir/build-scripts/build-scripts/.git/worktrees/*.path /tmp/_actions-runner-working-dir/_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1449732Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
2026-06-02T07:46:51.1469847Z /github/runner_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1485764Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1508165Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-06-02T07:46:51.1522662Z /github/runner_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1531107Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config
2026-06-02T07:46:51.1556791Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-06-02T07:46:51.1725284Z Removing credentials config '/tmp/_actions-runner-working-dir/_temp/git-credentials-e2263f4d-4316-44c4-9929-b3f7d7e18d45.config'
2026-06-02T07:46:51.1888764Z Cleaning up orphan processes
```
