### PR TITLE
Updated build script for pyyaml v6.0.3 on python3.14

### DIFF
--- a/p/pyyaml/build_info.json
+++ b/p/pyyaml/build_info.json
@@ -2,7 +2,7 @@
     "maintainer": "Harithanagothu2",
     "package_name": "pyyaml",
     "github_url": "https://github.com/yaml/pyyaml",
-    "version": "6.0",
+    "version": "6.0.3",
     "wheel_build": true,
     "default_branch": "master",
     "build_script": "pyyaml_ubi_9.3.sh",
@@ -12,9 +12,6 @@
     "use_non_root_user": false,
     "6.0.2": {
         "build_script":"pyyaml_ubi_9.3.sh"
-    },
-    "6.0.3": {
-        "build_script":"pyyaml_6.0_ubi_9.3.sh"
     },
     "6.*": {
        "build_script":"pyyaml_6.0_ubi_9.3.sh"

--- a/p/pyyaml/build_info.json
+++ b/p/pyyaml/build_info.json
@@ -13,6 +13,9 @@
     "6.0.2": {
         "build_script":"pyyaml_ubi_9.3.sh"
     },
+    "6.0.3": {
+        "build_script":"pyyaml_6.0_ubi_9.3.sh"
+    },
     "6.*": {
        "build_script":"pyyaml_6.0_ubi_9.3.sh"
     },

--- a/p/pyyaml/pyyaml_6.0_ubi_9.3.sh
+++ b/p/pyyaml/pyyaml_6.0_ubi_9.3.sh
@@ -32,7 +32,7 @@ import sys
 print(f"{sys.version_info.major}.{sys.version_info.minor}")
 EOF
 )
-if [[ "$PYVER" == "3.13" ]]; then
+if [[ "$PYVER" == "3.13" || "$PYVER" == "3.14" ]]; then
     pip3 install "cython>=3.0" wheel pytest
 else
     pip3 install "cython<3.0.0" wheel pytest
@@ -45,8 +45,8 @@ git clone $PACKAGE_URL $PACKAGE_NAME
 cd $PACKAGE_NAME
 git checkout $PACKAGE_VERSION
 
-# ----- Apply patch ONLY for Python 3.13 -----
-if [[ "$PYVER" == "3.13" ]]; then
+# ----- Apply patch ONLY for Python 3.13/3.14 -----
+if [[ "$PYVER" == "3.13" || "$PYVER" == "3.14" ]]; then
 
 cat << 'EOF' > patch_yaml_yaml_py313.patch
 diff --git a/yaml/_yaml.pyx b/yaml/_yaml.pyx
@@ -69,10 +69,11 @@ index 1b2c3f1..a8d9d42 100644
      cdef const char *value
 EOF
 
-echo "Applying Python 3.13 compatibility patch..."
+echo "Applying Python 3.13+ compatibility patch..."
 git apply patch_yaml_yaml_py313.patch
 
 fi
+
 if ! python3 setup.py install ; then
     echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"


### PR DESCRIPTION
### Updated build script to create PyYAML wheel for Python 3.14

- Earlier, the script used a Python version check of `== "3.13"`, which only handled Python 3.13 builds.
- Updated the condition to:
  ```bash
  if [[ "$PYVER" == "3.13" || "$PYVER" == "3.14" ]]; then
  ```
  so that the same build flow and compatibility patch are applied for both Python 3.13 and Python 3.14.


## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
