### PR TITLE
Update post_process_wheel.py

### DIFF
--- a/gha-script/post_process_wheel.py
+++ b/gha-script/post_process_wheel.py
@@ -101,12 +101,22 @@ def normalize_so_name(so_name):
     return re.sub(r'-[0-9a-f]{8,}(?=(?:\.so|\.\d))', '', so_name)
 
 def find_all_so_anywhere(so_name):
-    # Search for the .so file anywhere in the filesystem
+    # Search for the .so file anywhere in the filesystem, excluding site-packages
     try:
         result = run_command(["find", ".", "-type", "f", "-name", so_name])
         if len(result.stdout) == 0:
             result = run_command(["find", "/", "-type", "f", "-name", so_name])
-        return result.stdout.strip().splitlines()
+        
+        # Filter out paths containing site-packages to avoid using installed packages
+        all_paths = result.stdout.strip().splitlines()
+        filtered_paths = [p for p in all_paths if "site-packages" not in p]
+        
+        # If filtering removed all paths, log error and exit
+        if not filtered_paths and all_paths:
+            logger.error(f"All paths for {so_name} were in site-packages, no valid build path found")
+            sys.exit(1)
+        
+        return filtered_paths
     except Exception as e:
         logger.error(f"Failed to find .so files → {e}")
         return []


### PR DESCRIPTION
Updated the post_process_wheel.py to handle the cases where incorrect license was being picked up.

Wheel | license
-- | --
xgrammar-0.2.1+ppc64le1-cp310-cp310-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
xgrammar-0.2.1+ppc64le1-cp311-cp311-manylinux_2_34_ppc64le.whl | Apache-2.0
xgrammar-0.2.1+ppc64le1-cp312-cp312-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
xgrammar-0.2.1+ppc64le1-cp313-cp313-manylinux_2_34_ppc64le.whl | Apache-2.0

- The system was incorrectly fetching the license from the site-packages path **(./pyvenv_3.11/lib/python3.11/site-packages/tvm_ffi/lib/libtvm_ffi.so)** instead of using the correct build path **(./tvm-ffi/build/lib/libtvm_ffi.so)**.
- To address this, logic has been added to ignore all paths originating from site-packages.
- After doing this change getting licenses as below:

Wheel | license
-- | --
xgrammar-0.2.1+ppc64le1-cp310-cp310-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
xgrammar-0.2.1+ppc64le1-cp311-cp311-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
xgrammar-0.2.1+ppc64le1-cp312-cp312-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
xgrammar-0.2.1+ppc64le1-cp313-cp313-manylinux_2_34_ppc64le.whl | Apache-2.0, BSD-3-Clause
