### PR TITLE
Added build script for sqlalchemy v2.0.50

### DIFF
--- a/s/sqlalchemy/build_info.json
+++ b/s/sqlalchemy/build_info.json
@@ -10,11 +10,14 @@
 	"validate_build_script": true,
 	"wheel_build" : true,
 	"use_non_root_user": false,
+	"rel_2_0*": {
+	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
+	},
+	"rel_1_4*": {
+	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
+	},
 	"*.*.*": {
 	   "build_script": "sqlalchemy_ubi_9.3.sh"
-	},
-	"rel_2_0_50": {
-	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
 	}
 }
 

--- a/s/sqlalchemy/build_info.json
+++ b/s/sqlalchemy/build_info.json
@@ -2,7 +2,7 @@
 	"maintainer": "vivek8123",
 	"package_name": "SQLAlchemy",
 	"github_url": "https://github.com/sqlalchemy/sqlalchemy.git",
-	"version": "2.0.50",
+	"version": "rel_2_0_50",
 	"default_branch": "master",
 	"build_script": "sqlalchemy_ubi_9.3.sh",
 	"package_dir": "s/sqlalchemy",
@@ -13,7 +13,7 @@
 	"*.*.*": {
 	   "build_script": "sqlalchemy_ubi_9.3.sh"
 	},
-	"2.0.50": {
+	"rel_2_0_50": {
 	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
 	}
 }

--- a/s/sqlalchemy/build_info.json
+++ b/s/sqlalchemy/build_info.json
@@ -14,10 +14,10 @@
 	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
 	},
 	"rel_1_4*": {
-	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
+	   "build_script": "sqlalchemy_ubi_9.3.sh"
 	},
 	"*.*.*": {
-	   "build_script": "sqlalchemy_ubi_9.3.sh"
+	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"		
 	}
 }
 

--- a/s/sqlalchemy/build_info.json
+++ b/s/sqlalchemy/build_info.json
@@ -2,7 +2,7 @@
 	"maintainer": "vivek8123",
 	"package_name": "SQLAlchemy",
 	"github_url": "https://github.com/sqlalchemy/sqlalchemy.git",
-	"version": "1.4.39",
+	"version": "2.0.50",
 	"default_branch": "master",
 	"build_script": "sqlalchemy_ubi_9.3.sh",
 	"package_dir": "s/sqlalchemy",
@@ -12,6 +12,9 @@
 	"use_non_root_user": false,
 	"*.*.*": {
 	   "build_script": "sqlalchemy_ubi_9.3.sh"
+	},
+	"2.0.50": {
+	   "build_script": "sqlalchemy_2.0.50_ubi_9.3.sh"
 	}
 }
 

--- a/s/sqlalchemy/sqlalchemy_2.0.50_ubi_9.3.sh
+++ b/s/sqlalchemy/sqlalchemy_2.0.50_ubi_9.3.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package        : SQLAlchemy
+# Version        : rel_2_0_50
+# Source repo    : https://github.com/sqlalchemy/sqlalchemy.git
+# Tested on      : UBI 9.3
+# Language       : Python
+# Ci-Check   : True
+# Script License : Apache License, Version 2 or later
+# Maintainer     : vivek sharma<vivek.sharma20@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on the given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such cases, please
+#             contact the "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+
+PACKAGE_VERSION=${1:-'rel_2_0_50'}
+PACKAGE_NAME=SQLAlchemy
+PACKAGE_DIR=sqlalchemy
+PACKAGE_URL=https://github.com/sqlalchemy/sqlalchemy.git
+
+# Install necessary system packages
+yum install -y git gcc gcc-c++ make wget sudo python-devel openssl-devel bzip2-devel libffi-devel zlib-devel sqlite-devel
+
+# Upgrade pip and install necessary Python packages
+pip3 install greenlet
+pip3 install --upgrade pip setuptools wheel
+pip3 install pytest
+pip3 install mypy
+
+# Add /usr/local/bin to PATH
+export PATH=$PATH:/usr/local/bin/
+
+cwd=$(pwd)
+# --- Upgrade SQLite to >=3.35 (required for few sqlalchemy tests)
+cd /tmp && \
+    wget https://www.sqlite.org/2025/sqlite-autoconf-3510000.tar.gz && \
+    tar xzf sqlite-autoconf-3510000.tar.gz && \
+    cd sqlite-autoconf-3510000 && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && make install && \
+    ln -sf /usr/local/bin/sqlite3 /usr/bin/sqlite3 && \
+    ldconfig && \
+    sqlite3 --version && cd .. && \
+    rm -rf /tmp/sqlite-autoconf-3510000 && \
+    rm -f /tmp/sqlite-autoconf-3510000.tar.gz
+
+# Return to original directory
+cd $cwd
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+# Clone the repository
+git clone ${PACKAGE_URL}
+cd ${PACKAGE_DIR}
+git checkout ${PACKAGE_VERSION}
+
+# Disable C extensions BEFORE installation
+export DISABLE_SQLALCHEMY_CEXT=1
+
+# Upgrade pip and setuptools within the virtual environment
+pip install --upgrade pip setuptools wheel
+
+# Enable legacy editable mode for setuptools
+export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
+
+#commenting out the tag_build so it creates wheel without .dev0
+sed -i '/^\[egg_info\]/,/\[/{s/^\(tag_build = dev\)/# \1/}' setup.cfg
+
+# Install the package in editable mode with testing dependencies
+pip install -e .[testing]
+
+# Check if setup.py file exists and install the package
+if [ -f "setup.py" ]; then
+    if ! python3 setup.py install; then
+        echo "------------------${PACKAGE_NAME}: Install_fails------------------"
+        echo "${PACKAGE_URL} ${PACKAGE_NAME}"
+        echo "${PACKAGE_NAME} | ${PACKAGE_URL} | ${PACKAGE_VERSION} | GitHub | Fail | Install_Fails"
+        exit 1
+    fi
+    echo "setup.py file exists"
+else
+    echo "setup.py not present"
+fi
+
+# Run tests using pytest
+if command -v pytest &> /dev/null; then
+    if ! pytest -k "not postgresql and not mysql and not oracle and not mssql and not mypy and not test_slices_arent_in_mappings" \
+        -W ignore::DeprecationWarning --disable-warnings; then
+        echo "------------------${PACKAGE_NAME}: Tests_Fail------------------"
+        echo "${PACKAGE_URL} ${PACKAGE_NAME}"
+        echo "${PACKAGE_NAME} | ${PACKAGE_URL} | ${PACKAGE_VERSION} | GitHub | Fail | Tests_Fail"
+        exit 1
+    fi
+else
+    echo "pytest is not installed or not found in PATH"
+    exit 1
+fi


### PR DESCRIPTION
## Added build script for sqlalchemy v2.0.50. 
- Building SQLite ≥ 3.35 in sqlalchemy build script to avoid those three test failures caused by SQLite older version being used(this fix might be needed for other versions of sqlalchemy as well).
- Updated build-info.json for to add support for v2.0.50 (tag: rel_2_0_50).

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
