### PR TITLE
Refactor wheel build log naming logic

### DIFF
--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -227,16 +227,25 @@ jobs:
           bash ./gha-script/build_wheels.sh
 
           WORKSPACE=$(pwd)
-          LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py310_log.gz"
+          
+          # Determine log name based on whether wheel was generated
+          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
+            # Success: wheel generated - use wheel name without .whl extension
+            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+            LOG_NAME="${WHEEL_BASE}_py310_log.gz"
+          else
+            # Failure: no wheel - use package_name_vversion_pyversion format
+            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py310_log.gz"
+          fi
 
           if [ -f "$WORKSPACE/wheel_build_log" ]; then
             gzip "$WORKSPACE/wheel_build_log"
             mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
           else
             echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.10" \
-              > "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py310_log"
-            gzip "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py310_log"
-            LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py310_log.gz"
+              > "$WORKSPACE/${LOG_NAME%.gz}"
+            gzip "$WORKSPACE/${LOG_NAME%.gz}"
           fi
 
           chmod +x ./gha-script/upload-scripts/upload_file.sh
@@ -314,7 +323,16 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py311_log.gz"
+          # Determine log name based on whether wheel was generated
+          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
+            # Success: wheel generated - use wheel name without .whl extension
+            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+            LOG_NAME="${WHEEL_BASE}_py311_log.gz"
+          else
+            # Failure: no wheel - use package_name_vversion_pyversion format
+            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py311_log.gz"
+          fi
   
           if [ -f "$WORKSPACE/wheel_build_log" ]; then
             echo "Found wheel_build_log — compressing it"
@@ -323,9 +341,8 @@ jobs:
           else
             echo "wheel_build_log missing — creating fallback log"
             echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.11" \
-              > "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py311_log"
-            gzip "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py311_log"
-            LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py311_log.gz"
+              > "$WORKSPACE/${LOG_NAME%.gz}"
+            gzip "$WORKSPACE/${LOG_NAME%.gz}"
           fi
   
           echo "Final log file to upload: $LOG_NAME"
@@ -405,7 +422,16 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
         
           # ======= HANDLE LOG FILE SAFELY =======
-          LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py312_log.gz"
+          # Determine log name based on whether wheel was generated
+          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
+            # Success: wheel generated - use wheel name without .whl extension
+            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+            LOG_NAME="${WHEEL_BASE}_py312_log.gz"
+          else
+            # Failure: no wheel - use package_name_vversion_pyversion format
+            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py312_log.gz"
+          fi
 
           if [ -f "$WORKSPACE/wheel_build_log" ]; then
             echo "Found wheel_build_log — compressing it"
@@ -414,9 +440,8 @@ jobs:
           else
             echo "wheel_build_log missing — creating fallback log"
             echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.12" \
-              > "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py312_log"
-            gzip "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py312_log"
-            LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py312_log.gz"
+              > "$WORKSPACE/${LOG_NAME%.gz}"
+            gzip "$WORKSPACE/${LOG_NAME%.gz}"
           fi
 
           echo "Final log file to upload: $LOG_NAME"
@@ -497,7 +522,16 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py313_log.gz"
+          # Determine log name based on whether wheel was generated
+          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
+            # Success: wheel generated - use wheel name without .whl extension
+            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+            LOG_NAME="${WHEEL_BASE}_py313_log.gz"
+          else
+            # Failure: no wheel - use package_name_vversion_pyversion format
+            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py313_log.gz"
+          fi
   
           if [ -f "$WORKSPACE/wheel_build_log" ]; then
             echo "Found wheel_build_log — compressing it"
@@ -506,10 +540,9 @@ jobs:
           else
             echo "wheel_build_log missing — creating fallback log"
             echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.13" \
-              > "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py313_log"
-            gzip "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py313_log"
-            LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py313_log.gz"
-          fi 
+              > "$WORKSPACE/${LOG_NAME%.gz}"
+            gzip "$WORKSPACE/${LOG_NAME%.gz}"
+          fi
 
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh
@@ -589,7 +622,16 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py314_log.gz"
+          # Determine log name based on whether wheel was generated
+          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
+            # Success: wheel generated - use wheel name without .whl extension
+            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+            LOG_NAME="${WHEEL_BASE}_py314_log.gz"
+          else
+            # Failure: no wheel - use package_name_vversion_pyversion format
+            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py314_log.gz"
+          fi
   
           if [ -f "$WORKSPACE/wheel_build_log" ]; then
             echo "Found wheel_build_log — compressing it"
@@ -598,10 +640,9 @@ jobs:
           else
             echo "wheel_build_log missing — creating fallback log"
             echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.14" \
-              > "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py314_log"
-            gzip "$WORKSPACE/${PACKAGE_NAME}_${VERSION}_wheel_py314_log"
-            LOG_NAME="${PACKAGE_NAME}_${VERSION}_wheel_py314_log.gz"
-          fi 
+              > "$WORKSPACE/${LOG_NAME%.gz}"
+            gzip "$WORKSPACE/${LOG_NAME%.gz}"
+          fi
 
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh

--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -239,14 +239,9 @@ jobs:
             LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py310_log.gz"
           fi
 
-          if [ -f "$WORKSPACE/wheel_build_log" ]; then
-            gzip "$WORKSPACE/wheel_build_log"
-            mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
-          else
-            echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.10" \
-              > "$WORKSPACE/${LOG_NAME%.gz}"
-            gzip "$WORKSPACE/${LOG_NAME%.gz}"
-          fi
+          # Compress and rename the log file
+          gzip "$WORKSPACE/wheel_build_log"
+          mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
 
           chmod +x ./gha-script/upload-scripts/upload_file.sh
           bash ./gha-script/upload-scripts/upload_file.sh $LOG_NAME
@@ -334,16 +329,10 @@ jobs:
             LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py311_log.gz"
           fi
   
-          if [ -f "$WORKSPACE/wheel_build_log" ]; then
-            echo "Found wheel_build_log — compressing it"
-            gzip "$WORKSPACE/wheel_build_log"
-            mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
-          else
-            echo "wheel_build_log missing — creating fallback log"
-            echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.11" \
-              > "$WORKSPACE/${LOG_NAME%.gz}"
-            gzip "$WORKSPACE/${LOG_NAME%.gz}"
-          fi
+          # Compress and rename the log file
+          echo "Found wheel_build_log — compressing it"
+          gzip "$WORKSPACE/wheel_build_log"
+          mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
   
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh
@@ -433,16 +422,10 @@ jobs:
             LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py312_log.gz"
           fi
 
-          if [ -f "$WORKSPACE/wheel_build_log" ]; then
-            echo "Found wheel_build_log — compressing it"
-            gzip "$WORKSPACE/wheel_build_log"
-            mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
-          else
-            echo "wheel_build_log missing — creating fallback log"
-            echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.12" \
-              > "$WORKSPACE/${LOG_NAME%.gz}"
-            gzip "$WORKSPACE/${LOG_NAME%.gz}"
-          fi
+          # Compress and rename the log file
+          echo "Found wheel_build_log — compressing it"
+          gzip "$WORKSPACE/wheel_build_log"
+          mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
 
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh
@@ -533,16 +516,10 @@ jobs:
             LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py313_log.gz"
           fi
   
-          if [ -f "$WORKSPACE/wheel_build_log" ]; then
-            echo "Found wheel_build_log — compressing it"
-            gzip "$WORKSPACE/wheel_build_log"
-            mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
-          else
-            echo "wheel_build_log missing — creating fallback log"
-            echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.13" \
-              > "$WORKSPACE/${LOG_NAME%.gz}"
-            gzip "$WORKSPACE/${LOG_NAME%.gz}"
-          fi
+          # Compress and rename the log file
+          echo "Found wheel_build_log — compressing it"
+          gzip "$WORKSPACE/wheel_build_log"
+          mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
 
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh
@@ -633,16 +610,10 @@ jobs:
             LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py314_log.gz"
           fi
   
-          if [ -f "$WORKSPACE/wheel_build_log" ]; then
-            echo "Found wheel_build_log — compressing it"
-            gzip "$WORKSPACE/wheel_build_log"
-            mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
-          else
-            echo "wheel_build_log missing — creating fallback log"
-            echo "Wheel build completed for ${PACKAGE_NAME} ${VERSION} on Python 3.14" \
-              > "$WORKSPACE/${LOG_NAME%.gz}"
-            gzip "$WORKSPACE/${LOG_NAME%.gz}"
-          fi
+          # Compress and rename the log file
+          echo "Found wheel_build_log — compressing it"
+          gzip "$WORKSPACE/wheel_build_log"
+          mv "$WORKSPACE/wheel_build_log.gz" "$WORKSPACE/$LOG_NAME"
 
           echo "Final log file to upload: $LOG_NAME"
           chmod +x ./gha-script/upload-scripts/upload_file.sh

--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -228,16 +228,10 @@ jobs:
 
           WORKSPACE=$(pwd)
           
-          # Determine log name based on whether wheel was generated
-          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
-            # Success: wheel generated - use wheel name without .whl extension
-            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
-            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
-            LOG_NAME="${WHEEL_BASE}_py310_log.gz"
-          else
-            # Failure: no wheel - use package_name_vversion_pyversion format
-            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py310_log.gz"
-          fi
+          # Use wheel name for log naming
+          WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+          WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+          LOG_NAME="${WHEEL_BASE}_py310_log.gz"
 
           # Compress and rename the log file
           gzip "$WORKSPACE/wheel_build_log"
@@ -318,16 +312,10 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          # Determine log name based on whether wheel was generated
-          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
-            # Success: wheel generated - use wheel name without .whl extension
-            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
-            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
-            LOG_NAME="${WHEEL_BASE}_py311_log.gz"
-          else
-            # Failure: no wheel - use package_name_vversion_pyversion format
-            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py311_log.gz"
-          fi
+          # Use wheel name for log naming
+          WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+          WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+          LOG_NAME="${WHEEL_BASE}_py311_log.gz"
   
           # Compress and rename the log file
           echo "Found wheel_build_log — compressing it"
@@ -411,16 +399,10 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
         
           # ======= HANDLE LOG FILE SAFELY =======
-          # Determine log name based on whether wheel was generated
-          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
-            # Success: wheel generated - use wheel name without .whl extension
-            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
-            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
-            LOG_NAME="${WHEEL_BASE}_py312_log.gz"
-          else
-            # Failure: no wheel - use package_name_vversion_pyversion format
-            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py312_log.gz"
-          fi
+          # Use wheel name for log naming
+          WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+          WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+          LOG_NAME="${WHEEL_BASE}_py312_log.gz"
 
           # Compress and rename the log file
           echo "Found wheel_build_log — compressing it"
@@ -505,16 +487,10 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          # Determine log name based on whether wheel was generated
-          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
-            # Success: wheel generated - use wheel name without .whl extension
-            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
-            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
-            LOG_NAME="${WHEEL_BASE}_py313_log.gz"
-          else
-            # Failure: no wheel - use package_name_vversion_pyversion format
-            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py313_log.gz"
-          fi
+          # Use wheel name for log naming
+          WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+          WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+          LOG_NAME="${WHEEL_BASE}_py313_log.gz"
   
           # Compress and rename the log file
           echo "Found wheel_build_log — compressing it"
@@ -599,16 +575,10 @@ jobs:
           ls -lh "$WORKSPACE/wheel_build_log" || echo "wheel_build_log NOT found!"
           
           # ======= HANDLE LOG FILE SAFELY =======
-          # Determine log name based on whether wheel was generated
-          if ls "$WORKSPACE"/*.whl 1> /dev/null 2>&1; then
-            # Success: wheel generated - use wheel name without .whl extension
-            WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
-            WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
-            LOG_NAME="${WHEEL_BASE}_py314_log.gz"
-          else
-            # Failure: no wheel - use package_name_vversion_pyversion format
-            LOG_NAME="${PACKAGE_NAME}_v${VERSION}_py314_log.gz"
-          fi
+          # Use wheel name for log naming
+          WHEEL_FILE=$(ls "$WORKSPACE"/*.whl | head -n 1)
+          WHEEL_BASE=$(basename "${WHEEL_FILE%.whl}")
+          LOG_NAME="${WHEEL_BASE}_py314_log.gz"
   
           # Compress and rename the log file
           echo "Found wheel_build_log — compressing it"


### PR DESCRIPTION
Updated log naming logic for wheel builds across multiple Python versions to ensure correct log file names are generated based on wheel generation success with pattern :
 <wheel_name_without_.whl>_<py-version>_log.gz
eg : multidict-6.0.2+ppc64le2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le_py311_log.gz

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
