### PR TITLE
Fix gha-script permissions in PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -55,6 +55,10 @@ jobs:
           pip3 install --force-reinstall -v "requests==2.31.0"
           pip3 install --upgrade docker
 
+      - name: Fix gha-script permissions
+        run: sudo chown -R $USER:$USER ./gha-script
+
+
       - name: Set PR number
         run: echo "PR_NUMBER=${{ github.event.pull_request.number || inputs.pr_number }}" >> $GITHUB_ENV
 


### PR DESCRIPTION
Add step to fix permissions for gha-script

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
