### PR TITLE
Updated c-ares build script to avoid duplicating .so files

### DIFF
--- a/c/c-ares/cares_ubi_9.3.sh
+++ b/c/c-ares/cares_ubi_9.3.sh
@@ -55,7 +55,7 @@ git checkout $PACKAGE_VERSION
 
 mkdir -p prefix
 export PREFIX=$(pwd)/prefix
-mkdir build && cd build
+mkdir cmake-build && cd cmake-build
 
 export CARES_STATIC=OFF                                                                                                           
 export CARES_SHARED=ON                                                                                                            
@@ -94,10 +94,10 @@ WHL_VERSION=$(echo "$PACKAGE_VERSION" | grep -oE '[0-9_]+$' | tr '_' '.')
 wget https://raw.githubusercontent.com/ppc64le/build-scripts/refs/heads/master/c/c-ares/pyproject.toml
 sed -i "s/{PACKAGE_VERSION}/$WHL_VERSION/g" pyproject.toml
 
-python -m build --wheel --no-isolation --outdir="$CURRENT_DIR/"
+python -m build --wheel --no-isolation --outdir="$CURRENT_DIR/" -v
 
 echo "----------------------------------------------Testing pkg-------------------------------------------------------"
-cd build
+cd cmake-build
 #Test package
 if ! (ninja test) ; then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"


### PR DESCRIPTION
The original build script packaged the same shared libraries twice in the generated wheel.

**Previous wheel layout:**

```text
libcares.so
libcares.so.2
libcares.so.2.6.1

cares/lib/libcares.so
cares/lib/libcares.so.2
cares/lib/libcares.so.2.6.1
```

The `.so` files were present both at the wheel root and under `cares/lib/`, resulting in duplicate copies of the same libraries.

**Updated wheel layout:**

```text
cares/lib/libcares.so
cares/lib/libcares.so.2
cares/lib/libcares.so.2.6.1
```

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
