### PR TITLE
ODH: Make PACKAGE_VERSION configurable via argument

### DIFF
--- a/t/transformers/transformers_ubi_9.7.sh
+++ b/t/transformers/transformers_ubi_9.7.sh
@@ -14,8 +14,7 @@ set -eo pipefail
 #                  platform and package version. Functionality with newer
 #                  versions of the package or OS is not guaranteed.
 # -------------------------------------------------------------------------------
-
-PACKAGE_VERSION="v5.1.0"
+PACKAGE_VERSION=${1:-v5.1.0}
 PACKAGE_URL="https://github.com/huggingface/transformers.git"
 PACKAGE_DIR="transformers"
 TORCHCODEC_VERSION="v0.9.0"


### PR DESCRIPTION
Allow PACKAGE_VERSION to be set via script argument.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
