### PR TITLE
Updated build script for grpc-cpp

### DIFF
--- a/g/grpc-cpp/grpc_cpp_ubi_9.3.sh
+++ b/g/grpc-cpp/grpc_cpp_ubi_9.3.sh
@@ -141,7 +141,7 @@ cd $SCRIPT_DIR
 echo "------------ libprotobuf installed--------------"
 
 #re2 install from sosurce
-git clone http://github.com/google/re2
+git clone https://github.com/google/re2
 cd re2
 git checkout 2022-04-01
 git submodule update --init


### PR DESCRIPTION
- fixed link for re2 as http is blocked used https

### Import validation successful:
```
((venv_import) ) [root@fa3351aede23 grpccpp1]# pip install wheelhouse/grpc_cpp-1.68.0+ppc64le1-py3-none-manylinux_2_34_ppc64le.whl 
Processing ./wheelhouse/grpc_cpp-1.68.0+ppc64le1-py3-none-manylinux_2_34_ppc64le.whl
Installing collected packages: grpc-cpp
Successfully installed grpc-cpp-1.68.0+ppc64le1

[notice] A new release of pip is available: 23.2.1 -> 26.1.2
[notice] To update, run: pip install --upgrade pip
((venv_import) ) [root@fa3351aede23 grpccpp1]# ls venv_import/lib/python3.12/site-packages/
grpc_cpp-1.68.0+ppc64le1.dist-info  grpc_cpp.libs  grpccpp  pip  pip-23.2.1.dist-info
((venv_import) ) [root@fa3351aede23 grpccpp1]# python -c "import grpccpp; print('success')"
success
```

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
