### PR TITLE
Updated build script for pyzmq to fix test failures

### DIFF
--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file="; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings --ignore=zmq/tests/test_mypy.py; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings --ignore=zmq/tests/test_mypy.py; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file="; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings -k "not test_mypy_example[mongodb]"; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings --ignore=zmq/tests/test_mypy.py; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -52,7 +52,7 @@ git checkout $PACKAGE_VERSION
 
 #install python dependencies
 pip install cython==3.0.12 packaging pathspec==0.12.1 scikit-build-core==0.11.1 cmake==3.27.9 ninja==1.11.1.4 build
-pip install "setuptools_scm[toml]" pytest==6.2.5 pytest-asyncio==0.20.3 "pytest-timeout<2.0" tornado mypy
+pip install "setuptools_scm[toml]" pytest==6.2.5 pytest-asyncio==0.20.3 "pytest-timeout<2.0" tornado mypy==1.16.1
 
 
 #install

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file="; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file=" --python-version=$PYTHON_VERSION; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -23,7 +23,6 @@ PACKAGE_NAME=pyzmq
 PACKAGE_VERSION=${1:-v25.1.2}
 PACKAGE_URL=https://github.com/zeromq/pyzmq.git
 PACKAGE_DIR=pyzmq
-PYTHON_VERSION=${2:-3.12}
 CURRENT_DIR="${PWD}"
 
 # Install dependencies
@@ -65,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file=" --python-version=$PYTHON_VERSION; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings --override-ini="mypy-ini-file="; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -23,6 +23,7 @@ PACKAGE_NAME=pyzmq
 PACKAGE_VERSION=${1:-v25.1.2}
 PACKAGE_URL=https://github.com/zeromq/pyzmq.git
 PACKAGE_DIR=pyzmq
+PYTHON_VERSION=${2:-3.12}
 CURRENT_DIR="${PWD}"
 
 # Install dependencies

--- a/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
+++ b/p/pyzmq/pyzmq_v25.1.2_ubi_9.3.sh
@@ -64,7 +64,7 @@ if ! pip install -e . ; then
 fi
 
 export PYTHONPATH=$PWD/tests:$PWD
-if ! pytest -v --timeout=60 --capture=no -p no:warnings --ignore=zmq/tests/test_mypy.py; then
+if ! pytest -v --timeout=60 --capture=no -p no:warnings -k "not test_mypy_example[mongodb]"; then
     echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


Pinned mypy to 1.16.1 to fix the following test failure:

```
2026-07-07T16:33:47.4956868Z E       AssertionError: mypy.ini: [mypy]: python_version: Python 3.8 is not supported (must be 3.10 or higher)
2026-07-07T16:33:47.4960329Z E         examples/mongodb/controller.py:84: error: Argument 1 to "append" of "list" has incompatible type "str"; expected "bytes"  [arg-type]
2026-07-07T16:33:47.4964319Z E         examples/mongodb/controller.py:88: error: Argument 1 to "append" of "list" has incompatible type "str"; expected "bytes"  [arg-type]
2026-07-07T16:33:47.4967030Z E         Found 2 errors in 1 file (checked 2 source files)
```