### PR TITLE
numexpr: remove numpy version pin in 2.10.2 script

### DIFF
--- a/n/numexpr/numexpr_2.10.2_ubi_9.3.sh
+++ b/n/numexpr/numexpr_2.10.2_ubi_9.3.sh
@@ -35,7 +35,7 @@ git checkout $PACKAGE_VERSION
 #install pytest
 pip install pytest
 
-pip install numpy==2.0.2
+pip install numpy
 pip install -e .
 pip install tox
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
