### PR TITLE
Fix Ollama version displayed as 0.0.0 in the Ollama image

### DIFF
--- a/o/ollama/Dockerfiles/v0.30.10_ubi_9/Dockerfile
+++ b/o/ollama/Dockerfiles/v0.30.10_ubi_9/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "b9692" > LLAMA_CPP_VERSION
 ###############################################################################
 # Build Ollama (CMake)
 ###############################################################################
-RUN cmake -B build -DCMAKE_BUILD_TYPE=Release && \
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release -DOLLAMA_VERSION=${PACKAGE_VERSION} && \
     cmake --build build -j$(nproc)
 
 ###############################################################################


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [x] Did you have **Legal approvals** for patch files ? 


---
This PR contains only one change. When the image is used, the Ollama version is displayed as `0.0.0`, which has resulted in VM complaints.

<img width="491" height="52" alt="image" src="https://github.com/user-attachments/assets/5573ec9c-30ca-46cd-963c-e52a32ed966b" />


This change adds `DOLLAMA_VERSION=${PACKAGE_VERSION}` to ensure the correct Ollama version is displayed in the ollama image correctly.
<img width="465" height="55" alt="image" src="https://github.com/user-attachments/assets/79467c9b-e5ac-4327-9b78-9f8842dad0e8" />

**This fix resolve complaint issue.**


