### PR TITLE
Add z3-solver build script

### DIFF
--- a/z/z3-solver/LICENSE
+++ b/z/z3-solver/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/z/z3-solver/build-z3-ppc64le-ubi10.sh
+++ b/z/z3-solver/build-z3-ppc64le-ubi10.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+#
+# Package       : z3
+# Version       : z3-4.15.4
+# Source repo   : https://github.com/Z3Prover/z3
+# Tested on     : UBI 10 (ppc64le)
+# Language      : C++, Python
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Daniel Schenker <daniel.schenker@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+#
+# Clones the Z3 theorem prover, patches it for ppc64le, builds from source,
+# and produces a Python wheel.
+#
+# Designed to run inside a bare UBI 10 container. All required system packages
+# are installed via dnf at the start of the script.
+#
+# Output wheel:
+#   <output-dir>/z3_solver-4.15.4.0-cpXY-cpXY-linux_ppc64le.whl
+#
+# Usage:
+#   ./build-z3-rocm-ppc64le.sh [--version z3-4.15.4] [--workdir $HOME]
+#                               [--output-dir $HOME/vllm-wheels]
+#
+set -Eeuo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+Z3_VERSION="z3-4.15.4"
+WORK_DIR="${HOME}"
+OUTPUT_DIR=""          # resolved to ${WORK_DIR}/vllm-wheels after arg parsing
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+usage() {
+    cat <<EOF
+Usage:
+  $SCRIPT_NAME [options]
+
+Options:
+  --version VERSION     Z3 git tag to build (default: $Z3_VERSION)
+  --workdir DIR         Parent directory for the z3/ clone (default: $WORK_DIR)
+  --output-dir DIR      Directory to copy the built wheel into (default: <workdir>/vllm-wheels)
+  -h, --help            Show this help and exit
+EOF
+}
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)     Z3_VERSION="$2";   shift 2 ;;
+        --workdir)     WORK_DIR="$2";      shift 2 ;;
+        --output-dir)  OUTPUT_DIR="$2";    shift 2 ;;
+        -h|--help)     usage; exit 0 ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+# Resolve OUTPUT_DIR now that WORK_DIR is final
+OUTPUT_DIR="${OUTPUT_DIR:-${WORK_DIR}/vllm-wheels}"
+
+# ─── System packages ──────────────────────────────────────────────────────────
+info "Installing system dependencies"
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+dnf install -y \
+    git              \
+    gcc-toolset-15   \
+    python3.13       \
+    python3.13-devel
+
+# ─── GCC Toolset 15 ───────────────────────────────────────────────────────────
+info "Configuring GCC Toolset 15"
+GCC_TOOLSET_BIN="/opt/rh/gcc-toolset-15/root/usr/bin"
+if [[ -f /opt/rh/gcc-toolset-15/enable ]]; then
+    # shellcheck disable=SC1091
+    source /opt/rh/gcc-toolset-15/enable
+elif [[ -d "$GCC_TOOLSET_BIN" ]]; then
+    export PATH="$GCC_TOOLSET_BIN:$PATH"
+else
+    die "/opt/rh/gcc-toolset-15 not found — install gcc-toolset-15"
+fi
+echo "Using gcc: $(command -v gcc)  ($(gcc -dumpfullversion -dumpversion))"
+echo "Using ar:  $(command -v ar)"
+
+# ─── Venv ─────────────────────────────────────────────────────────────────────
+VENV_DIR="${WORK_DIR}/z3-build-env"
+[[ -d "$VENV_DIR" ]] || python3.13 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip setuptools wheel build
+
+# ─── Clone ────────────────────────────────────────────────────────────────────
+Z3_DIR="${WORK_DIR}/z3"
+if [[ ! -d "$Z3_DIR" ]]; then
+    git clone https://github.com/Z3Prover/z3.git "$Z3_DIR"
+else
+    info "z3 directory already exists — skipping clone"
+fi
+cd "$Z3_DIR"
+git checkout "$Z3_VERSION"
+
+# ─── Patch setup.py (ppc64le wheel tag) ───────────────────────────────────────
+info "Patching src/api/python/setup.py (ppc64le wheel tag)"
+python3 - <<'PYEOF'
+from pathlib import Path
+p = Path("src/api/python/setup.py")
+src = p.read_text()
+entry = "    ('linux', 'ppc64le'): 'manylinux2014_ppc64le',\n"
+if entry in src:
+    print("  setup.py already patched — skipping")
+elif "TAGS = {" in src:
+    p.write_text(src.replace("TAGS = {", "TAGS = {\n" + entry, 1))
+    print("  setup.py patched OK")
+else:
+    raise SystemExit("Could not find TAGS dict in setup.py")
+PYEOF
+
+# ─── Build ────────────────────────────────────────────────────────────────────
+python scripts/mk_make.py --prefix="$VIRTUAL_ENV"
+cd build
+make -j"$(nproc)"
+make install
+
+# ─── Wheel ────────────────────────────────────────────────────────────────────
+cd "$Z3_DIR/src/api/python"
+python setup.py bdist_wheel
+
+mkdir -p "$OUTPUT_DIR"
+cp dist/*.whl "$OUTPUT_DIR/"
+info "Z3 wheel: $(ls "$OUTPUT_DIR"/z3*.whl)"

--- a/z/z3-solver/build_info.json
+++ b/z/z3-solver/build_info.json
@@ -11,7 +11,7 @@
     "docker_build": "false",
     "validate_build_script": "true",
     "use_non_root_user": "false",
-    "wheel_build": "True",
+    "wheel_build": "true",
     "wheel_name": "z3-solver",
 
     "required_versions": {

--- a/z/z3-solver/build_info.json
+++ b/z/z3-solver/build_info.json
@@ -1,0 +1,21 @@
+{
+    "maintainer":"Daniel-Schenker",
+    "package_name" : "z3-solver",
+    "github_url":"https://github.com/z3prover/z3",
+    "version": "z3-4.15.4",
+    "default_branch": "master",
+    "category": "default",
+    "package_dir": "z/z3-solver",
+    "docker_cmd":"NA",
+    "build_script": "build-z3-ppc64le-ubi10.sh",
+    "docker_build": "False",
+    "validate_build_script": "True",
+    "use_non_root_user": "True",
+    "wheel_build": "True",
+    "wheel_name": "z3-solver",
+
+    "required_versions": {
+        "Releases": "[z3-4.15.4]",
+        "Tags": "[z3-4.15.4]"
+    },
+}

--- a/z/z3-solver/build_info.json
+++ b/z/z3-solver/build_info.json
@@ -10,7 +10,7 @@
     "build_script": "build-z3-ppc64le-ubi10.sh",
     "docker_build": "false",
     "validate_build_script": "true",
-    "use_non_root_user": "True",
+    "use_non_root_user": "false",
     "wheel_build": "True",
     "wheel_name": "z3-solver",
 

--- a/z/z3-solver/build_info.json
+++ b/z/z3-solver/build_info.json
@@ -9,7 +9,7 @@
     "docker_cmd":"NA",
     "build_script": "build-z3-ppc64le-ubi10.sh",
     "docker_build": "false",
-    "validate_build_script": "True",
+    "validate_build_script": "true",
     "use_non_root_user": "True",
     "wheel_build": "True",
     "wheel_name": "z3-solver",

--- a/z/z3-solver/build_info.json
+++ b/z/z3-solver/build_info.json
@@ -8,7 +8,7 @@
     "package_dir": "z/z3-solver",
     "docker_cmd":"NA",
     "build_script": "build-z3-ppc64le-ubi10.sh",
-    "docker_build": "False",
+    "docker_build": "false",
     "validate_build_script": "True",
     "use_non_root_user": "True",
     "wheel_build": "True",


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container (Validated on UBI 10 container)
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [x] Did you have **Legal approvals** for patch files ? 

This PR introduces a build script to build the z3-solver package on ppc64le. It was tested and successful in a base UBI10 container image. There is one patch that the script applies at build time. Please do let me know if there are any changes needed to the script (ie final location for wheel file etc...). The script can be run with `./build-z3-ppc64le-ubi10.sh`, no arguments are required but can be passed to edit locations and versions as needed.
