### PR TITLE
fix: handle non-root privilege requirements in create_wheel_wrapper.sh

### DIFF
--- a/gha-script/create_wheel_wrapper.sh
+++ b/gha-script/create_wheel_wrapper.sh
@@ -46,48 +46,48 @@ install_python_version() {
     echo
     case $version in
     "3.11" | "3.12")
-        yum install -y python${version} python${version}-devel python${version}-pip
+        $YUM install -y python${version} python${version}-devel python${version}-pip
         ;;
     "3.10")
         if ! python3.10 --version &>/dev/null; then
-            yum install -y sudo zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
-            yum install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
+            $YUM install -y zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
+            $YUM install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
             wget https://www.python.org/ftp/python/3.10.20/Python-3.10.20.tgz
             tar xf Python-3.10.20.tgz
             cd Python-3.10.20
             ./configure --prefix=/usr/local --enable-optimizations --enable-shared
             make -j2
             make altinstall
-            echo "/usr/local/lib" > /etc/ld.so.conf.d/python-local.conf && ldconfig
+            echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/python-local.conf && sudo ldconfig
             echo "Completed..."
             cd .. && rm -rf Python-3.10.20.tgz
         fi
         ;;
     "3.13")
         if ! python3.13 --version &>/dev/null; then
-            yum install -y sudo zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
-            yum install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
+            $YUM install -y zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
+            $YUM install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
             wget https://www.python.org/ftp/python/3.13.10/Python-3.13.10.tgz
             tar xzf Python-3.13.10.tgz
             cd Python-3.13.10
             ./configure --prefix=/usr/local --enable-optimizations --enable-shared
             make -j2
             make altinstall
-            echo "/usr/local/lib" > /etc/ld.so.conf.d/python-local.conf && ldconfig
+            echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/python-local.conf && sudo ldconfig
             cd .. && rm -rf Python-3.13.10.tgz
         fi
         ;;
     "3.14")
         if ! python3.14 --version &>/dev/null; then
-            yum install -y sudo zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
-            yum install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
+            $YUM install -y zlib-devel wget ncurses git make cmake openssl-devel xz xz-devel
+            $YUM install -y libffi libffi-devel sqlite sqlite-devel sqlite-libs bzip2-devel
             wget https://www.python.org/ftp/python/3.14.3/Python-3.14.3.tgz
             tar xzf Python-3.14.3.tgz
             cd Python-3.14.3
             ./configure --prefix=/usr/local --enable-optimizations --enable-shared
             make -j2
             make altinstall
-            echo "/usr/local/lib" > /etc/ld.so.conf.d/python-local.conf && ldconfig
+            echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/python-local.conf && sudo ldconfig
             cd .. && rm -rf Python-3.14.3.tgz
         fi
         ;;


### PR DESCRIPTION
The wrapper script was failing in non-root container builds (use_non_root_user: true) because several commands require elevated privileges but were called without sudo.

Changes:
- Remove redundant 'sudo' from $YUM install package lists in Python 3.10/3.13/3.14 source-build cases — sudo is already present when $YUM resolves to 'sudo yum'
- Replace direct writes to /etc/ld.so.conf.d/ and bare ldconfig calls with 'sudo tee' and 'sudo ldconfig' in Python 3.10/3.13/3.14 source-build cases, since writing to /etc requires root regardless of how yum is invoked

Note: sudo tee / sudo ldconfig are safe for root builds too since sudo is a no-op when already running as root.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
