### PR TITLE
fix(hmmlearn): fix wheel name

### DIFF
--- a/h/hmmlearn/hmmlearn_ubi_9.6.sh
+++ b/h/hmmlearn/hmmlearn_ubi_9.6.sh
@@ -30,11 +30,13 @@ OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
 SOURCE=Github
 
 # Install system dependencies
-yum install -y git python3 python3-devel gcc-toolset-13 gcc-toolset-13-gcc-gfortran make wget sudo openblas-devel
+yum install -y --disablerepo=rpmfusion* git python3 python3-devel \
+    gcc-toolset-13 gcc-toolset-13-gcc-gfortran \
+    make wget sudo openblas-devel
 
 export PATH=$PATH:/usr/local/bin/
 export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH}
 
 # Install Python build and test dependencies.
 # scipy and scikit-learn are built from source on ppc64le; openblas-devel
@@ -61,6 +63,16 @@ fi
 # NumPy 2.5 deprecated in-place shape assignment (array.shape = new_shape);
 # replace it with np.reshape() which works on all supported NumPy versions.
 sed -i 's/a_sum\.shape = shape/a_sum = a_sum.reshape(shape)/g' src/hmmlearn/utils.py
+
+# Patch setup.py: add -U_GLIBCXX_ASSERTIONS to suppress the _ZSt21__glibcxx_assert_fail
+# symbol. The system Python on RHEL 9 is built with -D_GLIBCXX_ASSERTIONS which
+# propagates to all C extensions; this symbol is absent from the system libstdc++ (GCC 11).
+sed -i 's/Pybind11Extension("hmmlearn._hmmc", \["ext\/_hmmc.cpp"\], cxx_std=11)/Pybind11Extension("hmmlearn._hmmc", ["ext\/_hmmc.cpp"], cxx_std=11, extra_compile_args=["-U_GLIBCXX_ASSERTIONS"])/' setup.py
+
+# Pin the version string so setuptools_scm does not append git-dirty metadata
+# (the sed patch above makes the working tree dirty, which would otherwise
+# produce a wheel name like hmmlearn-0.3.3.post0+g<hash>.d<date>...).
+export SETUPTOOLS_SCM_PRETEND_VERSION="$PACKAGE_VERSION"
 
 # Install the package (builds pybind11 C++ extension _hmmc)
 if ! python3 -m pip install ./; then


### PR DESCRIPTION
Test cases were failing, so added below change.

- The system Python on RHEL 9 is built with -D_GLIBCXX_ASSERTIONS, which causes the _hmmc.so extension to reference _ZSt21__glibcxx_assert_fail a symbol missing from the system's libstdc++ (GCC 11), resulting in an ImportError at runtime.

- Adding -U_GLIBCXX_ASSERTIONS to the compile args cancels that inherited flag, preventing the missing symbol from being referenced and allowing the package to load successfully.

If we dont add it.

- The package installs successfully but fails to import with this error at runtime:
ImportError: _hmmc.cpython-311-powerpc64le-linux-gnu.so: undefined symbol: _ZSt21__glibcxx_assert_failPKciS0_S0_

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
