### PR TITLE
Updated build scripts for pydantic-core 

### DIFF
--- a/p/pydantic-core/build_info.json
+++ b/p/pydantic-core/build_info.json
@@ -1,16 +1,22 @@
 {
    "maintainer": "kiranNukal",
    "package_name": "pydantic-core",
-   "github_url": "https://github.com/pydantic/pydantic-core",
-   "version": "v2.27.1",
+   "github_url": "https://github.com/pydantic/pydantic",
+   "version": "core-v2.46.4",
    "default_branch": "main",
-   "build_script": "pydantic-core_ubi_9.6.sh",
+   "build_script": "pydantic-core_core-v2.46.4_ubi9.6.sh",
    "package_dir": "p/pydantic-core",
    "docker_build": false,
    "wheel_build": true,
    "validate_build_script": true,
    "use_non_root_user": false,
+   "v*.*.*": {
+     "build_script": "pydantic-core_ubi_9.6.sh"
+   },
+   "core-v*.*.*": {
+     "build_script": "pydantic-core_core-v2.46.4_ubi9.6.sh"
+   },
    "*": {
-     "build_script":"pydantic-core_ubi_9.6.sh"
-  }
+     "build_script": "pydantic-core_core-v2.46.4_ubi9.6.sh"
+   }
 }

--- a/p/pydantic-core/pydantic-core_core-v2.46.4_ubi9.6.sh
+++ b/p/pydantic-core/pydantic-core_core-v2.46.4_ubi9.6.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : pydantic-core
+# Version       : core-v2.46.4
+# Source repo   : https://github.com/pydantic/pydantic.git
+# Tested on     : UBI:9.6
+# Language      : Python
+# Ci-Check  : True
+# Script License: MIT License
+# Maintainer    : Vrusha Naik <Vrusha.Naik@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# ----------------------------------------------------------------------------
+set -ex 
+
+# Variables
+PACKAGE_NAME=pydantic-core
+PACKAGE_VERSION=core-v2.46.4
+PACKAGE_URL=https://github.com/pydantic/pydantic.git
+PACKAGE_DIR=pydantic/pydantic-core
+
+# Install dependencies
+yum install -y git python3 python3-devel.ppc64le gcc-toolset-13 make wget sudo cmake
+pip install "pytest<9"
+
+export PATH=$PATH:/usr/local/bin/
+export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
+export LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:$LD_LIBRARY_PATH
+
+OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
+SOURCE=Github
+
+# Install rust
+if ! command -v rustc &> /dev/null
+then
+    wget https://static.rust-lang.org/dist/rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
+    tar -xzf rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
+    cd rust-1.75.0-powerpc64le-unknown-linux-gnu
+    sudo ./install.sh
+    export PATH=$HOME/.cargo/bin:$PATH
+    rustc -V
+    cargo -V
+    cd ../
+fi
+
+# Clone the repo
+git clone $PACKAGE_URL
+cd $PACKAGE_DIR
+git checkout $PACKAGE_VERSION
+
+# Install the package
+if ! python3 -m pip install ./; then
+    echo "------------------$PACKAGE_NAME:install_fails------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Fail | Install_Failed"
+    exit 1
+fi
+
+pip3 install hypothesis pytest-timeout inline_snapshot pytest-benchmark jsonschema pytest_examples dirty_equals pytz rich faker pytest-mock eval_type_backport typing_inspection pytest-run-parallel
+
+test_status=1
+# Run pytest if any matching test files found
+if ls */test_*.py > /dev/null 2>&1 && [ $test_status -ne 0 ]; then
+    echo "Running pytest..."
+    (python3 -m pytest --ignore=tests/test_docstrings.py) && test_status=0 || test_status=$?
+fi
+
+# Final test result output
+if [ $test_status -eq 0 ]; then
+    echo "------------------$PACKAGE_NAME:install_and_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Pass | Both_Install_and_Test_Success"
+    exit 0
+else
+    echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | $SOURCE | Fail | Install_success_but_test_Fails"
+    exit 2
+fi

--- a/p/pydantic-core/pydantic-core_core-v2.46.4_ubi9.6.sh
+++ b/p/pydantic-core/pydantic-core_core-v2.46.4_ubi9.6.sh
@@ -37,17 +37,9 @@ OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
 SOURCE=Github
 
 # Install rust
-if ! command -v rustc &> /dev/null
-then
-    wget https://static.rust-lang.org/dist/rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
-    tar -xzf rust-1.75.0-powerpc64le-unknown-linux-gnu.tar.gz
-    cd rust-1.75.0-powerpc64le-unknown-linux-gnu
-    sudo ./install.sh
-    export PATH=$HOME/.cargo/bin:$PATH
-    rustc -V
-    cargo -V
-    cd ../
-fi
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+
 
 # Clone the repo
 git clone $PACKAGE_URL

--- a/p/pydantic-core/pydantic-core_ubi_9.6.sh
+++ b/p/pydantic-core/pydantic-core_ubi_9.6.sh
@@ -51,13 +51,9 @@ if ! python3 -m pip install -e .; then
     exit 1
 fi
 
-pip3 install hypothesis pytest-timeout inline_snapshot pytest-benchmark jsonschema pytest_examples dirty_equals pytz rich faker pytest-mock eval_type_backport typing_inspection
+pip3 install hypothesis pytest-timeout inline_snapshot pytest-benchmark jsonschema pytest_examples dirty_equals pytz rich faker pytest-mock eval_type_backport typing_inspection pytest-run-parallel
 
-# Skipping this test because it uses `pytest.raises(match="")`, which is invalid under pytest>=8.
-# Empty match strings always pass and trigger PytestWarning, so the test is not meaningful until fixed.
-# Skipping test_hypothesis.py, test_frozenset.py, test_list.py, and test_set.py because they use
-# @pytest.mark.thread_unsafe from pytest-run-parallel which is not installed, causing collection errors.
-if ! (pytest --ignore=tests/test_docstrings.py --ignore=tests/validators/test_arguments.py --ignore=tests/test_hypothesis.py --ignore=tests/validators/test_frozenset.py --ignore=tests/validators/test_list.py --ignore=tests/validators/test_set.py); then
+if ! (pytest --ignore=tests/test_docstrings.py -vv); then
     echo "------------------$PACKAGE_NAME:install_success_but_test_fails---------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
     echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail |  Install_success_but_test_Fails"


### PR DESCRIPTION
- fixed original build script to run the ignored tests.
- add new build script to support building packages for tags available for pydantic-core on the main pydantic repo.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
