### PR TITLE
Fix version format and update script comments

### DIFF
--- a/t/tilelang/tilelang_0.1.10_ubi_10.2.sh
+++ b/t/tilelang/tilelang_0.1.10_ubi_10.2.sh
@@ -1,3 +1,23 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : tilelang
+# Version       : 0.1.10
+# Source repo   : https://github.com/tile-ai/tilelang
+# Tested on     : UBI:10.2
+# Language      : Python, C++
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Daniel Schenker <daniel.schenker@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# -----------------------------------------------------------------------------
+
 set -e
 
 PACKAGE_NAME=tilelang

--- a/t/tilelang/tilelang_0.1.10_ubi_10.2.sh
+++ b/t/tilelang/tilelang_0.1.10_ubi_10.2.sh
@@ -1,27 +1,7 @@
-#!/bin/bash -e
-# -----------------------------------------------------------------------------
-#
-# Package       : tilelang
-# Version       : 0.1.10
-# Source repo   : https://github.com/tile-ai/tilelang
-# Tested on     : UBI:10.2
-# Language      : Python, C++
-# Ci-Check      : True
-# Script License: Apache License, Version 2 or later
-# Maintainer    : Daniel Schenker <daniel.schenker@ibm.com>
-#
-# Disclaimer: This script has been tested in root mode on given
-# ==========  platform using the mentioned version of the package.
-#             It may not work as expected with newer versions of the
-#             package and/or distribution. In such case, please
-#             contact "Maintainer" of this script.
-#
-# -----------------------------------------------------------------------------
-
 set -e
 
 PACKAGE_NAME=tilelang
-PACKAGE_VERSION=${1:-0.1.10}
+PACKAGE_VERSION=${1:-v0.1.10}
 PACKAGE_URL=https://github.com/tile-ai/tilelang
 PACKAGE_DIR=tilelang
 CURRENT_DIR=$(pwd)
@@ -119,7 +99,7 @@ pip install --trusted-host wheels.developerfirst.ibm.com \
 cd $CURRENT_DIR
 git clone --recursive $PACKAGE_URL $PACKAGE_DIR
 cd $PACKAGE_DIR
-git checkout "v${PACKAGE_VERSION}"
+git checkout "${PACKAGE_VERSION}"
 git submodule sync --recursive
 git submodule update --init --recursive
 


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 

Fixes following issue observed with OSE build:

```
Submodule path '3rdparty/tvm/3rdparty/tvm-ffi/3rdparty/dlpack': checked out '84d107bf416c6bab9ae68ad285876600d230490d'
Submodule path '3rdparty/tvm/3rdparty/tvm-ffi/3rdparty/libbacktrace': checked out '793921876c981ce49759114d7bb89bb89b2d3a2d'
error: pathspec 'vv0.1.10' did not match any file(s) known to git
Traceback (most recent call last):
  File "/tmp/_actions-runner-working-dir/build-scripts/build-scripts/gha-script/build_wheels.py", line 85, in <module>
    trigger_build_wheel(sys.argv[1],sys.argv[2],sys.argv[3],sys.argv[4],sys.argv[5],sys.argv[6])
  File "/tmp/_actions-runner-working-dir/build-scripts/build-scripts/gha-script/build_wheels.py", line 79, in trigger_build_wheel
    raise Exception(f"Build script validation failed for {file_name}!")
Exception: Build script validation failed for t/tilelang/tilelang_0.1.10_ubi_10.2.sh!
Wheel build failed for t/tilelang/tilelang_0.1.10_ubi_10.2.sh v0.1.10 
```