### PR TITLE
fix: strip leading whitespace from CHANGED_FILES lines in safety-net loop

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -243,7 +243,7 @@ jobs:
           # This guarantees every changed script in the PR is tested regardless of
           # how build_info.json version blocks are structured or overlap.
           # If no .sh files changed (build_info.json only), this loop does nothing.
-          while IFS= read -r changed_script; do
+          while read -r changed_script; do
             [[ "$changed_script" != *.sh ]] && continue
             [ ! -f "$changed_script" ] && continue
             raw_tested_on=$(grep "^# Tested on" "$changed_script" | head -1 \


### PR DESCRIPTION

When GitHub Actions expands a multi-line job output via ${{ needs.check_changes.outputs.changed_files }}, it indents every continuation line with the surrounding YAML indentation (2 spaces). This caused the second and subsequent filenames in CHANGED_FILES to arrive with leading spaces in the build_info job's environment.

The safety-net loop in the "Emit per-UBI outputs" step used `while IFS= read -r`, which preserves all whitespace. As a result, the file existence check `[ ! -f "$changed_script" ]` received a path like "  t/torchaudio/torchaudio_v2.11_ubi_9.5.sh" (with leading spaces), which does not resolve on disk. The script was silently skipped, SCRIPT_UBI9 was never populated, and all UBI9 build/wheel jobs were skipped for the PR.

Fix: drop `IFS=` so bash automatically trims leading/trailing whitespace from each line read from CHANGED_FILES. Git-produced file paths never contain leading spaces, so this is safe for all existing and future builds.

Fixes: UBI9 (and potentially UBI8/UBI10) jobs being skipped in pr-build.yaml when a PR changes more than one file.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
