### PR TITLE
fix: override VERSION with actual script version in PR wheel build jobs

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -532,6 +532,11 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          # Override VERSION with the actual package version from the script header.
+          # VERSION in variable.sh/scanner-env.sh is the build_info.json version block
+          # key (e.g. "v2.10.*"), which is a match pattern, not a real git tag.
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -575,6 +580,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -620,6 +627,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -663,6 +672,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -706,6 +717,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -750,6 +763,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -794,6 +809,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -839,6 +856,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -883,6 +902,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh
@@ -927,6 +948,8 @@ jobs:
           if [ "$WHEEL_BUILD" != "true" ]; then echo "Skipping  -  WHEEL_BUILD=false"; exit 0; fi
           BUILD_SCRIPT_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^$PACKAGE_DIR/.*\.sh$" || true)
           [ -z "$BUILD_SCRIPT_CHANGED" ] && echo "Skipping  -  no .sh changes" && exit 0
+          SCRIPT_VERSION=$(grep "^# Version" "$PKG_DIR_PATH$THIS_SCRIPT" | head -1 | cut -d':' -f2- | xargs)
+          [ -n "$SCRIPT_VERSION" ] && export VERSION="$SCRIPT_VERSION"
           sudo chown -R $USER:$USER .
           export ENABLE_CVE_SCAN=false
           chmod +x ./gha-script/build_wheels.sh; bash ./gha-script/build_wheels.sh


### PR DESCRIPTION
VERSION stored in variable.sh and scanner-env.sh is the matched build_info.json version block key (e.g. "v2.10.*"), which is a wildcard pattern used for version resolution — not a real git tag. All 10 wheel build jobs were passing this pattern directly to build_wheels.sh, which forwarded it into the container where the build script attempted `git checkout 'v2.10.*'`, failing with:

  error: pathspec 'v2.10.*' did not match any file(s) known to git

Fix: after sourcing variable.sh/scanner-env.sh in every wheel job, read the actual package version from the `# Version` header of the build script file and export it as VERSION, overriding the block key. This is consistent with how execute_changed_scripts.py already handles VERSION for the build_ubi8/9/10 jobs.

The override is guarded by `[ -n "$SCRIPT_VERSION" ]` so if the header is absent for any reason VERSION falls back to the existing value — no regression for other packages.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
