### PR TITLE
Add build script for torch-c-dlpack-ext

### DIFF
--- a/t/torch-c-dlpack-ext/LICENSE
+++ b/t/torch-c-dlpack-ext/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/t/torch-c-dlpack-ext/build_info.json
+++ b/t/torch-c-dlpack-ext/build_info.json
@@ -1,0 +1,17 @@
+{
+    "maintainer":"Daniel-Schenker",
+    "package_name" : "torch-c-dlpack-ext",
+    "github_url":"https://github.com/apache/tvm-ffi",
+    "version": "0.1.5",
+    "default_branch": "main",
+    "package_dir": "t/torch-c-dlpack-ext",
+    "build_script": "torch-c-dlpack-ext_0.1.5_ubi_10.2.sh",
+    "docker_build": false,
+    "validate_build_script": true,
+    "use_non_root_user": false,
+    "wheel_build": true,
+    "required_versions": {"Releases": ["*"],"Tags": ["0.1.5"]},
+    "*": {
+    "build_script": "torch-c-dlpack-ext_0.1.5_ubi_10.2.sh"
+   }
+}

--- a/t/torch-c-dlpack-ext/build_info.json
+++ b/t/torch-c-dlpack-ext/build_info.json
@@ -2,7 +2,7 @@
     "maintainer":"Daniel-Schenker",
     "package_name" : "torch-c-dlpack-ext",
     "github_url":"https://github.com/apache/tvm-ffi",
-    "version": "v0.1.5",
+    "version": "v0.1.12",
     "default_branch": "main",
     "package_dir": "t/torch-c-dlpack-ext",
     "build_script": "torch-c-dlpack-ext_0.1.5_ubi_10.2.sh",
@@ -10,7 +10,7 @@
     "validate_build_script": true,
     "use_non_root_user": false,
     "wheel_build": true,
-    "required_versions": {"Releases": ["*"],"Tags": ["0.1.5"]},
+    "required_versions": {"Releases": ["*"],"Tags": ["v0.1.12"]},
     "*": {
     "build_script": "torch-c-dlpack-ext_0.1.5_ubi_10.2.sh"
    }

--- a/t/torch-c-dlpack-ext/build_info.json
+++ b/t/torch-c-dlpack-ext/build_info.json
@@ -2,7 +2,7 @@
     "maintainer":"Daniel-Schenker",
     "package_name" : "torch-c-dlpack-ext",
     "github_url":"https://github.com/apache/tvm-ffi",
-    "version": "0.1.5",
+    "version": "v0.1.5",
     "default_branch": "main",
     "package_dir": "t/torch-c-dlpack-ext",
     "build_script": "torch-c-dlpack-ext_0.1.5_ubi_10.2.sh",

--- a/t/torch-c-dlpack-ext/torch-c-dlpack-ext_0.1.5_ubi_10.2.sh
+++ b/t/torch-c-dlpack-ext/torch-c-dlpack-ext_0.1.5_ubi_10.2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : torch-c-dlpack-ext
+# Version       : 0.1.5
+# Source repo   : https://github.com/apache/tvm-ffi (addons/torch_c_dlpack_ext/)
+# Tested on     : UBI:10.2
+# Language      : Python, C++
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Daniel Schenker <daniel.schenker@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# -----------------------------------------------------------------------------
+
+set -e
+
+PACKAGE_NAME=torch-c-dlpack-ext
+PACKAGE_VERSION=${1:-v0.1.12}
+PACKAGE_URL=https://github.com/apache/tvm-ffi
+PACKAGE_DIR=tvm-ffi
+CURRENT_DIR=$(pwd)
+
+# Install dependencies
+yum install -y git gcc-toolset-15 gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ \
+    python3.12 python3.12-devel python3.12-pip make
+
+# Configure GCC Toolset 15
+if [[ -f /opt/rh/gcc-toolset-15/enable ]]; then
+    source /opt/rh/gcc-toolset-15/enable
+elif [[ -d /opt/rh/gcc-toolset-15/root/usr/bin ]]; then
+    export PATH="/opt/rh/gcc-toolset-15/root/usr/bin:$PATH"
+    export LD_LIBRARY_PATH="/opt/rh/gcc-toolset-15/root/usr/lib64:$LD_LIBRARY_PATH"
+else
+    echo "ERROR: gcc-toolset-15 not found"
+    exit 1
+fi
+
+echo "Using gcc: $(gcc --version | head -1)"
+
+# Install Python build tools
+pip install --upgrade pip setuptools wheel build
+
+# apache-tvm-ffi must be installed before building torch-c-dlpack-ext because
+# the custom build_backend.py imports tvm_ffi.libinfo.find_dlpack_include_path
+# at wheel build time to locate the dlpack headers.
+pip install apache-tvm-ffi==${PACKAGE_VERSION#v}
+
+# Install PyTorch (CPU build sufficient -- the build backend checks
+# torch.cuda.is_available() and falls back to a CPU-only .so when no GPU is
+# present on the build host; the ROCm .so is JIT-compiled at first runtime
+# import on the actual GPU host)
+pip install torch \
+    --trusted-host wheels.developerfirst.ibm.com \
+    --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/
+
+# Clone repository (reuses existing clone if already present from the
+# apache-tvm-ffi build script running on the same host)
+cd $CURRENT_DIR
+rm -rf $PACKAGE_DIR
+git clone $PACKAGE_URL $PACKAGE_DIR
+cd $PACKAGE_DIR
+git checkout $PACKAGE_VERSION
+
+# Build wheel from the addon subdirectory.
+# The custom build_backend.py (setuptools>=61.0 only) compiles
+# libtorch_c_dlpack_addon_torch<major><minor>-cpu.so via the host CXX compiler
+# and bundles it into the wheel package directory before calling
+# setuptools.build_meta.build_wheel.
+cd addons/torch_c_dlpack_ext
+python3.12 -m build --wheel --no-isolation
+
+echo "Built wheel:"
+ls dist/torch_c_dlpack_ext-*.whl

--- a/t/torch-c-dlpack-ext/torch-c-dlpack-ext_0.1.5_ubi_10.2.sh
+++ b/t/torch-c-dlpack-ext/torch-c-dlpack-ext_0.1.5_ubi_10.2.sh
@@ -74,6 +74,26 @@ git checkout $PACKAGE_VERSION
 # setuptools.build_meta.build_wheel.
 cd addons/torch_c_dlpack_ext
 python3.12 -m build --wheel --no-isolation
+cp dist/*.whl $CURRENT_DIR/
 
-echo "Built wheel:"
-ls dist/torch_c_dlpack_ext-*.whl
+# Install package
+if ! pip install dist/torch_c_dlpack_ext-*.whl ; then
+    echo "------------------$PACKAGE_NAME:Install_fails-------------------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+    exit 1
+fi
+
+# Run tests
+cd $CURRENT_DIR/$PACKAGE_DIR
+if ! python3.12 -c "import torch_c_dlpack_ext; print('torch_c_dlpack_ext import test passed')" ; then
+    echo "------------------$PACKAGE_NAME:Install_success_but_test_fails---------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_success_but_test_Fails"
+    exit 2
+else
+    echo "------------------$PACKAGE_NAME:Install_&_test_both_success-------------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub  | Pass |  Both_Install_and_Test_Success"
+    exit 0
+fi


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container (ubi10)
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [x] Did you have **Legal approvals** for patch files ? 

This PR adds the build script for torch-c-dlpack-ext package. This is an interesting one as this package is an add-on to the apache-tvm-ffi package, and therefore lives in the same GitHub repository. Additionally there is some weirdness with versions as the version of torch-c-dlpack-ext seems to be hard linked to the version of apache-tvm-ffi that is installed when building. Do let me know if there are any modifications needed to the build script or build info files.
