### PR TITLE
Ubi10 script for duckdb==1.5.4

### DIFF
--- a/d/duckdb/build_info.json
+++ b/d/duckdb/build_info.json
@@ -5,13 +5,13 @@
   "version": "v1.5.4",
   "default_branch": "main",
   "package_dir": "d/duckdb",
-  "build_script": "duckdb_1.5.4_ubi_9.6.sh",
+  "build_script": "duckdb_1.5.4_ubi_10.2.sh",
   "docker_build": false,
   "validate_build_script": true,
   "wheel_build" : true,
   "use_non_root_user": false,
   "1.5.4": {
-     "build_script": "duckdb_1.5.4_ubi_9.6.sh"
+     "build_script": "duckdb_1.5.4_ubi_10.2.sh"
   },
   "*": {
      "build_script": "duckdb_ubi_9.6.sh"

--- a/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
+++ b/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
@@ -28,7 +28,7 @@ PYTHON_VERSION=${2:-3.12}
 SOURCE_ROOT="$(pwd)"
 
 # Install necessary system packages
-dnf install -y git gcc-toolset-15 make cmake ninja-build libomp-devel python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip
+dnf install -y git gcc-toolset-15 make cmake ninja-build libomp-devel python3 python3-devel python3-pip
 
 export PATH="/opt/rh/gcc-toolset-15/root/usr/bin:$PATH"
 gcc --version

--- a/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
+++ b/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
@@ -18,6 +18,8 @@
 #
 # -----------------------------------------------------------------------------
 
+set -e
+
 PACKAGE_NAME=duckdb-python
 PACKAGE_VERSION=${1:-v1.5.4}
 PACKAGE_DIR=duckdb-python
@@ -27,9 +29,12 @@ SOURCE_ROOT="$(pwd)"
 
 # Install necessary system packages
 dnf install -y \
+    git \
     gcc-toolset-15 \
+    make \
     cmake \
     ninja-build \
+    libomp-devel \
     python3.12 \
     python3.12-devel \
     python3.12-pip
@@ -37,12 +42,24 @@ dnf install -y \
 export PATH="/opt/rh/gcc-toolset-15/root/usr/bin:$PATH"
 gcc --version
 
-python3.12 -m pip install --upgrade pip setuptools
+python3.12 -m pip install --upgrade pip setuptools build wheel ninja pybind11
+
+# Clone the repository
+git clone ${PACKAGE_URL}
+cd ${PACKAGE_NAME}
+git checkout ${PACKAGE_VERSION}
+
+# Populate the DuckDB C++ engine submodule — without this the CMake
+# configure step fails because external/duckdb/ is an empty directory.
+git submodule update --init --recursive
+
+export DUCKDB_BUILD_PYTHON=1
+export DUCKDB_BUILD_STATIC=1
 
 # -- Build wheel --------------------------------------------------------------
-python3.12 -m pip wheel . --no-deps -w "${CURRENT_DIR}/dist/"
+python3.12 -m build --wheel
 
-WHEEL=$(find "${CURRENT_DIR}/dist" -name "duckdb-*.whl" | head -1)
+WHEEL=$(find dist -name "duckdb-*.whl" | head -1)
 if [ -z "$WHEEL" ]; then
     echo "ERROR: wheel not found after build"
     exit 1
@@ -57,7 +74,7 @@ fi
 cd "${SOURCE_ROOT}"
 
 # -- Install ------------------------------------------------------------------
-pip3.12 install "$WHEEL"
+python3.12 -m pip install "${PACKAGE_DIR}/${WHEEL}"
 
 if ! python${PYTHON_VERSION} - <<EOF
 import duckdb

--- a/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
+++ b/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
@@ -24,25 +24,16 @@ PACKAGE_NAME=duckdb-python
 PACKAGE_VERSION=${1:-v1.5.4}
 PACKAGE_DIR=duckdb-python
 PACKAGE_URL=https://github.com/duckdb/duckdb-python.git
-PYTHON_VERSION=3.12
+PYTHON_VERSION=${2:-3.12}
 SOURCE_ROOT="$(pwd)"
 
 # Install necessary system packages
-dnf install -y \
-    git \
-    gcc-toolset-15 \
-    make \
-    cmake \
-    ninja-build \
-    libomp-devel \
-    python3.12 \
-    python3.12-devel \
-    python3.12-pip
+dnf install -y git gcc-toolset-15 make cmake ninja-build libomp-devel python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip
 
 export PATH="/opt/rh/gcc-toolset-15/root/usr/bin:$PATH"
 gcc --version
 
-python3.12 -m pip install --upgrade pip setuptools build wheel ninja pybind11
+python${PYTHON_VERSION} -m pip install --upgrade pip setuptools build wheel ninja pybind11
 
 # Clone the repository
 git clone ${PACKAGE_URL}
@@ -57,7 +48,7 @@ export DUCKDB_BUILD_PYTHON=1
 export DUCKDB_BUILD_STATIC=1
 
 # -- Build wheel --------------------------------------------------------------
-python3.12 -m build --wheel
+python${PYTHON_VERSION} -m build --wheel
 
 WHEEL=$(find dist -name "duckdb-*.whl" | head -1)
 if [ -z "$WHEEL" ]; then
@@ -74,7 +65,7 @@ fi
 cd "${SOURCE_ROOT}"
 
 # -- Install ------------------------------------------------------------------
-python3.12 -m pip install "${PACKAGE_DIR}/${WHEEL}"
+python${PYTHON_VERSION} -m pip install "${PACKAGE_DIR}/${WHEEL}"
 
 if ! python${PYTHON_VERSION} - <<EOF
 import duckdb

--- a/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
+++ b/d/duckdb/duckdb_1.5.4_ubi_10.2.sh
@@ -1,0 +1,90 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : duckdb
+# Version       : v1.5.4
+# Source repo   : https://github.com/duckdb/duckdb-python.git
+# Tested on     : UBI:10.2
+# Language      : Python, C++
+# Ci-Check  : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Jason Cho <jason.cho2@ibm.com>
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# -----------------------------------------------------------------------------
+
+PACKAGE_NAME=duckdb-python
+PACKAGE_VERSION=${1:-v1.5.4}
+PACKAGE_DIR=duckdb-python
+PACKAGE_URL=https://github.com/duckdb/duckdb-python.git
+PYTHON_VERSION=3.12
+SOURCE_ROOT="$(pwd)"
+
+# Install necessary system packages
+dnf install -y \
+    gcc-toolset-15 \
+    cmake \
+    ninja-build \
+    python3.12 \
+    python3.12-devel \
+    python3.12-pip
+
+export PATH="/opt/rh/gcc-toolset-15/root/usr/bin:$PATH"
+gcc --version
+
+python3.12 -m pip install --upgrade pip setuptools
+
+# -- Build wheel --------------------------------------------------------------
+python3.12 -m pip wheel . --no-deps -w "${CURRENT_DIR}/dist/"
+
+WHEEL=$(find "${CURRENT_DIR}/dist" -name "duckdb-*.whl" | head -1)
+if [ -z "$WHEEL" ]; then
+    echo "ERROR: wheel not found after build"
+    exit 1
+fi
+echo "Wheel: $WHEEL"
+
+# Copy wheel to /home/tester so the wrapper script can locate it without rebuilding
+if [ -d /home/tester ]; then
+    cp "${WHEEL}" /home/tester/
+fi
+
+cd "${SOURCE_ROOT}"
+
+# -- Install ------------------------------------------------------------------
+pip3.12 install "$WHEEL"
+
+if ! python${PYTHON_VERSION} - <<EOF
+import duckdb
+
+# Ensure correct package loaded
+assert hasattr(duckdb, "connect"), "duckdb.connect missing"
+
+con = duckdb.connect()
+
+# 1 Basic SQL test
+assert con.execute("select 42").fetchall() == [(42,)]
+
+# 2 Version check (SQL side)
+version_sql = con.execute("select version()").fetchone()[0]
+assert version_sql.startswith("${PACKAGE_VERSION}")
+
+# 3 Python package version check
+assert duckdb.__version__ == "${PACKAGE_VERSION#v}"
+
+print("All DuckDB runtime tests passed.")
+EOF
+then
+    echo "------------------$PACKAGE_NAME: Tests_Fail------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Tests_Fail"
+    exit 2
+else
+    echo "------------------$PACKAGE_NAME: Install & Test Success ------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Pass | Both_Install_and_Test_Success"
+    exit 0
+fi


### PR DESCRIPTION
- This PR is the copy PR for  https://github.com/ppc64le/build-scripts/pull/8364 PR.

- Updated the DuckDB build script to support multiple Python versions and fixed build failures caused by missing clone package step, missing dependencies, uninitialized submodules and incorrect Python versions.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
