### PR TITLE
Update template and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,98 +25,177 @@ Please follow the below rules while contributing your build script to this repo.
 	# ----------------------------------------------------------------------------
 	```
    **If the build-script doesn't contain any of the field in above header, that leads to  `ValueError` in ci check.**
-3. Please mention in notes that, whether the script is made for root user or non-root user.
-4. Always keep the package version/commitID in variable. Try to take version as parameter otherwise take a default version number you are working on. Below is the example:
+3. The `# Tested on` header field is **mandatory** and must declare the target UBI version in the format `UBI:<major>.<minor>` (e.g. `# Tested on : UBI:10.2`). CI will hard-block the PR if this field is absent or unrecognisable.
+4. Please mention in notes that, whether the script is made for root user or non-root user.
+5. Always keep the package version/commitID in variable. Try to take version as parameter otherwise take a default version number you are working on. Below is the example:
 	``` shell
 	VERSION=${1:-v5.0.2}
 	# v5.0.2 is the default version, in case of no parameter passed to the script.
 	```
-5. Check if package/component directory already exists and add new file into it. If not, create a directory for new package/component and place LICENSE file into it.
-6. Package name & Filenames must be in **lowercase**.
-7. Get Legal approvals incase of any code change/patch. 
-8. Build script templates can be found [here](https://github.com/ppc64le/build-scripts/tree/master/templates).
-9. Make sure to include test step for package so build get validated with available test's in source.
-10. Test the build script on clean UBI container before raising PR. Include test logs as part of PR.
-11. Try to create a branch on your forked repo for each PR.
+6. Check if package/component directory already exists and add new file into it. If not, create a directory for new package/component and place LICENSE file into it.
+7. Package name & Filenames must be in **lowercase**.
+8. Get Legal approvals incase of any code change/patch. 
+9. Build script templates can be found [here](https://github.com/ppc64le/build-scripts/tree/master/templates).
+10. Make sure to include test step for package so build get validated with available test's in source.
+11. Test the build script on clean UBI container before raising PR. Include test logs as part of PR.
+12. Try to create a branch on your forked repo for each PR.
 
 ---
 
-## PR Workflow Overview (Simplified)
+## `build_info.json` — Version Block Key Rules
+
+The `version` field in `build_info.json` (e.g. `"version": "v2.11.0"`) and the version block keys nested inside the file (e.g. `"v2.11.0": { ... }`) **must match exactly**.
+
+- A mismatch (e.g. key `"1.5.4"` vs field `"v1.5.4"`) will cause CI to block the PR with an error such as:
+  ```
+  ERROR: version block key '1.5.4' does not match the 'version' field value 'v1.5.4' in build_info.json.
+  ```
+- The wildcard key `"*"` is intentionally excluded from this check — it is a catch-all fallback.
+- Each version block must list **separate build scripts per UBI major** (UBI8, UBI9, UBI10) so that CI can route each script to the correct build job automatically.
+
+---
+
+## PR Workflow Overview
 
 ### Trigger
-- Pull Request
-- Manual workflow dispatch
+- Pull Request targeting `master` or `replica-master`
+- Manual `workflow_dispatch` (re-trigger a failing PR build on a larger runner)
 
 ---
 
 ### Pipeline Stages
 
+#### 0. Change Detection (`check_changes`)
+- Runs on `ubuntu-latest` (lightweight, no ppc64le runner needed)
+- Detects whether any relevant files changed: `build_info.json`, `.sh` scripts, or `Dockerfile`
+- Excludes changes under `gha-script/`, `process_bom/`, `script/`, `templates/`, `travis-*` directories
+- Sets `should_build=true/false` — downstream jobs are skipped entirely when `false`
+- For `workflow_dispatch`, always sets `should_build=true`
+
+---
+
 #### 1. Preparation Stage (`build_info`)
-- Validate build scripts using CI checks:
+- Runs on a ppc64le runner (`ubuntu-24.04-ppc64le-p10`)
+- Validates build scripts using CI checks:
   - Shebang must be present
-  - Mandatory header fields must exist
+  - Mandatory header fields must exist (including `# Tested on`)
   - Naming conventions must be followed
   - Directory structure must be correct
-- Identify changed files in the PR
-- Locate and parse `build_info.json`
-- Extract flags:
-  - `wheel_build`
-  - `docker_build`
+- Locates and parses `build_info.json`:
+  - Resolves the correct version block by matching changed `.sh` files against `build_script` arrays (best-overlap wins; `"*"` key is skipped)
+  - Preserves the raw `.version` field as `PACKAGE_VERSION` (the real package version, e.g. `v2.11.0`) separately from the matched version block key (`VERSION`, e.g. `v2.10.*`)
+  - Validates that the resolved version block key matches `PACKAGE_VERSION` exactly (unless the key contains `*`); mismatches cause a hard CI failure
+- Runs `read_buildinfo.sh` to populate per-UBI script variables (`SCRIPT_UBI8`, `SCRIPT_UBI9`, `SCRIPT_UBI10`)
+- For every changed `.sh` file enforces two hard rules:
+  1. The script **must** have a `# Tested on` header
+  2. The UBI slot for that script **must** already be populated by `read_buildinfo.sh`; an empty slot indicates a version block key mismatch and will block the PR
+- Emits per-UBI outputs (`script_ubi8`, `script_ubi9`, `script_ubi10`) as `{script, tested_on}` JSON objects
+- Extracts job control flags:
+  - `wheel_build_enabled` — `true` when `wheel_build=true` **and** a `.sh` file changed
+  - `docker_build_enabled` — `true` when `docker_build=true` **and** a `Dockerfile` changed
+  - `build_package_enabled` — `true` when `build_info.json` or a `.sh` file changed
+  - `has_sh_changes`, `has_dockerfile_changes`
+- Archives `package-cache` artifact (environment variables and metadata) for downstream jobs
 
 ---
 
-#### 2. Build Stage (Always Runs)
-- Build the package using `gha-script/build_package.sh`
-- The build must:
-  - Successfully install/build the package
-  - Include test steps for validation
+#### 2. Build Stage (Parallel, per UBI version)
+
+Three independent build jobs run in parallel. Each job only runs when a script exists for that UBI version:
+
+| Job | Condition |
+|-----|-----------|
+| `build_ubi8` | `build_package_enabled=true` and `script_ubi8` is non-empty |
+| `build_ubi9` | `build_package_enabled=true` and `script_ubi9` is non-empty |
+| `build_ubi10` | `build_package_enabled=true` and `script_ubi10` is non-empty |
+
+Each job:
+- Downloads the `package-cache` artifact
+- Runs `execute_changed_scripts.py` filtered to only the script assigned to that UBI version
+- Executes the build inside the correct UBI container
 
 ---
 
-#### 3. Conditional Execution (Parallel Jobs)
+#### 3. Wheel Build Stage (Parallel, per UBI × Python version)
 
-**Wheel Build**
-- Runs only if:
-  - `wheel_build = true`
-  - Build script (`.sh`) is modified
-- Builds wheels across multiple Python versions (3.10 – 3.14)
+Runs only when `wheel_build_enabled=true`. Jobs are split by UBI version and Python version:
 
-**Docker Build**
-- Runs only if:
-  - `docker_build = true`
-  - `Dockerfile` is modified
-- Builds Docker image and stores it as artifact
+| Job | UBI | Python | `continue-on-error` |
+|-----|-----|--------|---------------------|
+| `wheel_build_ubi8_py311` | UBI8 | 3.11 | No |
+| `wheel_build_ubi8_py312` | UBI8 | 3.12 | No |
+| `wheel_build_ubi9_py310` | UBI9 | 3.10 | No |
+| `wheel_build_ubi9_py311` | UBI9 | 3.11 | No |
+| `wheel_build_ubi9_py312` | UBI9 | 3.12 | No |
+| `wheel_build_ubi9_py313` | UBI9 | 3.13 | Yes (best-effort) |
+| `wheel_build_ubi9_py314` | UBI9 | 3.14 | Yes (best-effort) |
+| `wheel_build_ubi10_py312` | UBI10 | 3.12 | No |
+| `wheel_build_ubi10_py313` | UBI10 | 3.13 | Yes (best-effort) |
+| `wheel_build_ubi10_py314` | UBI10 | 3.14 | Yes (best-effort) |
+
+> **UBI10 note:** Python 3.10 and 3.11 are not supported on UBI10. Only py312–py314 wheel jobs run.
+
+Each wheel job:
+- Runs `build_wheels.sh` with `ENABLE_CVE_SCAN=false` (PR builds do not publish)
+- Post-processes the wheel (license injection, IBM classifier, RECORD update); version suffix addition is **skipped** in PR builds because COS credentials are absent
+- Verifies that at least one `.whl` file was produced
+
+---
+
+#### 4. Docker Build Stage (`build_docker`)
+- Runs only when `docker_build_enabled=true`
+- Builds the Docker image using `build_docker.sh`
+- Saves the image as a `.tar` artifact inside `package-cache`
 
 ---
 
 ### Execution Logic Summary
 
-| Change Type            | Wheel Build | Docker Build |
-|----------------------|------------|--------------|
-| Build script changed | Yes        | No           |
-| Dockerfile changed   | No         | Yes          |
-| Both changed         | Yes        | Yes          |
-| Only config changes  | No         | No           |
-| Irrelevant changes   | No         | No           |
+| Change Type              | Build (UBI8/9/10) | Wheel Build | Docker Build |
+|--------------------------|:-----------------:|:-----------:|:------------:|
+| Build script (`.sh`) changed | Yes (matching UBI) | Yes (if `wheel_build=true`) | No |
+| `Dockerfile` changed     | No  | No | Yes (if `docker_build=true`) |
+| Both changed             | Yes | Yes (if `wheel_build=true`) | Yes (if `docker_build=true`) |
+| `build_info.json` only   | Yes | No | No |
+| Only config/infra changes | No | No | No |
 
 ---
 
 ### Artifacts
-- `package-cache` (environment variables and metadata)
-- Build logs (available in case of failures)
+- `package-cache` — environment variables, per-UBI script assignments, and metadata used by all downstream jobs
+- Build logs — available in GitHub Actions UI on failure
 
 ---
 
 ### Notes
-- CI will fail if validation checks do not pass
-- Ensure `build_info.json` is complete and correct
+- CI will hard-block the PR if:
+  - Any changed `.sh` file is missing the `# Tested on` header
+  - The version block key in `build_info.json` does not exactly match the `version` field value (unless it contains `*`)
+  - The UBI slot for a changed script is empty (version block not properly wired)
+  - Validation checks (`validate_builds.py`) do not pass
+- Ensure `build_info.json` is complete, correct, and that version block keys exactly match the `version` field
 - Enable `wheel_build` / `docker_build` only when required
-- Test scripts locally before raising a PR
-
+- Test scripts locally on a clean UBI container before raising a PR
 
 ---
 
 ### Pipeline Flow
 
-Preparation → Build → (Wheel Build + Docker Build in Parallel if applicable)
-
+```
+check_changes
+    └── build_info
+            ├── build_ubi8      (parallel)
+            ├── build_ubi9      (parallel)
+            ├── build_ubi10     (parallel)
+            ├── wheel_build_ubi8_py311   \
+            ├── wheel_build_ubi8_py312    |
+            ├── wheel_build_ubi9_py310    |
+            ├── wheel_build_ubi9_py311    | all parallel
+            ├── wheel_build_ubi9_py312    |
+            ├── wheel_build_ubi9_py313    |
+            ├── wheel_build_ubi9_py314    |
+            ├── wheel_build_ubi10_py312   |
+            ├── wheel_build_ubi10_py313   |
+            ├── wheel_build_ubi10_py314  /
+            └── build_docker    (parallel)
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,8 @@ Runs only when `wheel_build_enabled=true`. Jobs are split by UBI version and Pyt
 | `wheel_build_ubi10_py313` | UBI10 | 3.13 | Yes (best-effort) |
 | `wheel_build_ubi10_py314` | UBI10 | 3.14 | Yes (best-effort) |
 
+> **UBI8 note:** Python 3.10, 3.13, and 3.14 are not supported on UBI8. Only py311 and py312 wheel jobs run.
+>
 > **UBI10 note:** Python 3.10 and 3.11 are not supported on UBI10. Only py312–py314 wheel jobs run.
 
 Each wheel job:

--- a/templates/build_info_template.json
+++ b/templates/build_info_template.json
@@ -2,7 +2,7 @@
     "maintainer":"Github-id of the maintainer Mandatory Argument.",
     "package_name" : "Name of the packages (Eg: vault) Mandatory Argument.",
     "github_url":"Github URL for the package (Eg: https://github.com/hashicorp/vault.git) Mandatory Argument.",
-    "version": "Release version or Tag version available in github repo (Eg: v1.12.0). Mandatory Argument.",
+    "version": "Release version or Tag version available in github repo (Eg: v1.12.0). Mandatory Argument. NOTE: version block keys nested below must match this value exactly (e.g. if this is 'v1.12.0', the block key must also be 'v1.12.0', not '1.12.0').",
     "default_branch": "default checkout version available in github repo (Eg: master). Mandatory Argument.",
     "category": "Category of the build-script (Eg: default/rhp). Optional Argument.",
     "package_dir": "Directory path to the package on build-scripts repo (Eg: v/vault/)",
@@ -13,15 +13,16 @@
     "use_non_root_user": "Boolean variable to run build-script as non root user. Optional argument. Default value is `false` (Eg: true/false)",
     "wheel_build": "Boolean variable to enable or disable building wheel for a package. Optional argument. Default value is `false` (Eg: true/false)",
     "wheel_name": "Name of the wheel (Eg: torch would be wheel name for pytorch package) optional argument to handle scenarios where we have different name in build-scripts and devpi.",
+    "auditwheel_exclude": "Array of shared-library glob patterns to exclude from auditwheel repair. Optional argument. Used when a library must not be bundled into the wheel (Eg: [\"libcuda.so*\", \"libcudart.so*\"]).",
 
     "required_versions": {
         "Releases": "Array of releases that are required for the package (Eg for fetching all versions: ['*']). Optional argument.",
         "Tags": "Array of tags that are required for the package (Eg for fetching specific versions: ['v1.0.0', 'v1.1']). Optional argument."
     },
 
-    "version string(s)/version regex(es) (Eg: `v8.1.*, v8.2.0`)": {
+    "version string(s)/version regex(es) — key must exactly match the top-level 'version' field value (Eg: `v1.12.0`). Wildcard keys (Eg: `v8.1.*`) are allowed as catch-all fallbacks but are exempt from the exact-match check.": {
         "dir": "Directory name on which `docker build` should run. Mention directory name under `Dockerfile` directory of a package. (Eg: 8.1.0_ubi_8 - Incase if elasticsearch)",
-        "build_script": "Version specific build-script. If not mentioned, default build-script will be picked which is mentioned at outside of Tag details (Eg: elasticsearch_v8.1.1_ubi_8.5.sh).",
+        "build_script": "Build script(s) for this version. Can be a single string or an array. When multiple UBI targets are needed, provide one entry per UBI major version so CI can route each script to the correct build job (UBI8, UBI9, UBI10). Each script must contain a '# Tested on : UBI:<major>.<minor>' header that declares its target. (Eg: [\"pkg_ubi_8.10.sh\", \"pkg_ubi_9.4.sh\", \"pkg_ubi_10.2.sh\"])",
         "base_docker_image": "Mention base docker image which is used in DockerFile (FROM ). Optional argument. Default value is `registry.redhat.com/ubi8/ubi:latest`.",
         "base_docker_variant": "Base docker image variant. Allowed values are | redhat | ubuntu | alpine |. Optional argument. Default value is `redhat`.",
         "args": {


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


* docs: update CONTRIBUTING.md to reflect multi-UBI pipeline and strict validation rules

- Make '# Tested on : UBI:<major>.<minor>' header mandatory; CI hard-blocks if missing
- Add build_info.json version block key exact-match requirement and wildcard exemption
- Document Stage 0 (check_changes) gating downstream jobs on relevant file changes
- Rewrite Stage 1 (build_info): PACKAGE_VERSION tracking, key validation, per-UBI outputs
- Replace single build stage with parallel build_ubi8/9/10 jobs
- Document 10-job wheel matrix (UBI8 py311/312, UBI9 py310–314, UBI10 py312–314)
- Note suffix addition skipped in PR builds when COS credentials are absent
- Replace flat pipeline flow text with ASCII tree diagram

* docs: update build_info_template.json with UBI routing, auditwheel_exclude, and key-match note

- Add inline NOTE to 'version' field: version block keys must exactly match
  this value (e.g. 'v1.12.0' field → key must be 'v1.12.0', not '1.12.0')
- Add 'auditwheel_exclude' field documenting the array of shared-library
  glob patterns excluded from auditwheel repair (e.g. libcuda.so*)
- Rename version block descriptor key to state the exact-match rule and
  wildcard (*) exemption explicitly
- Expand 'build_script' in version block to document array form: when
  multiple UBI targets are needed, provide one script per UBI major
  (UBI8, UBI9, UBI10); each script's '# Tested on' header determines
  which build job picks it up

* Added ubi8 related information