### PR TITLE
Add build script for OpenRAG 0.5.1 (UBI 10)

### DIFF
--- a/o/openrag/LICENSE
+++ b/o/openrag/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 IBM 
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/o/openrag/README.md
+++ b/o/openrag/README.md
@@ -1,0 +1,119 @@
+# openrag ppc64le Build Script
+
+Build and installation verification script for [openrag](https://github.com/langflow-ai/openrag) v0.5.1 on IBM Power (ppc64le), tested on UBI 10.0.
+
+## Prerequisites
+
+- A ppc64le machine (Power9 or Power10) running Linux
+- Podman or Docker installed
+- Internet access to:
+  - `registry.access.redhat.com` (UBI 10 base image — no auth required)
+  - `https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/` (ppc64le devpi index — no auth required)
+  - `https://github.com/afsanjar/openrag` (source repo — public)
+
+## Usage
+
+Clone the build-scripts repo and run the script inside a UBI 10 container, which mirrors the CI environment exactly:
+
+```bash
+git clone https://github.com/ppc64le/build-scripts
+cd build-scripts
+
+podman run --rm -it \
+  -v $(pwd)/o/openrag/openrag_v0.5.1_ubi_10.0.sh:/build/openrag_v0.5.1_ubi_10.0.sh:z \
+  registry.access.redhat.com/ubi10/ubi:10.0 \
+  bash /build/openrag_v0.5.1_ubi_10.0.sh
+```
+
+Alternatively, run directly on a UBI 10 ppc64le host:
+
+```bash
+bash openrag_v0.5.1_ubi_10.0.sh
+```
+
+## Extracting the built wheel
+
+The build script runs inside a `--rm` container, so the wheel is destroyed when
+the container exits. To keep it, mount a host output directory:
+
+```bash
+mkdir -p ~/openrag-dist
+
+podman run --rm -it \
+  -v $(pwd)/o/openrag/openrag_v0.5.1_ubi_10.0.sh:/build/openrag_v0.5.1_ubi_10.0.sh:z \
+  -v ~/openrag-dist:/output:z \
+  registry.access.redhat.com/ubi10/ubi:10.0 \
+  bash -c "bash /build/openrag_v0.5.1_ubi_10.0.sh && cp /openrag/dist/openrag-0.5.1-py3-none-any.whl /output/"
+
+ls ~/openrag-dist/
+# openrag-0.5.1-py3-none-any.whl
+```
+
+The wheel is pure Python (`py3-none-any`) — it is architecture-neutral and can
+be built on any platform (Mac, x86, ppc64le) and installed on any other.
+
+## Expected output
+
+A passing run ends with:
+
+```
+------------------openrag:build_and_install_success----------
+openrag | https://github.com/afsanjar/openrag | 0.5.1 | "Red Hat Enterprise Linux 10.0 (Coughlan)" | GitHub | Pass | Build_and_Install_Success
+```
+
+## What the script does
+
+| Phase | Details |
+|---|---|
+| System deps | Installs `git`, `curl`, `gcc`, `gcc-c++`, `make`, `openblas-devel` via `dnf` |
+| uv + Python | Installs [uv](https://docs.astral.sh/uv/), then fetches a standalone Python 3.13 ppc64le build via `uv python install 3.13` |
+| Clone | Clones the `ppc64le-0.5.1` branch from `https://github.com/afsanjar/openrag` |
+| Build | Runs `uv build --python 3.13` with the ppc64le devpi index for compatible wheels |
+| Install | Creates a fresh venv at `/tmp/openrag-venv`, installs the wheel and all dependencies |
+| Verify | Runs `import tui.main` against the venv Python to confirm the entry point is importable |
+
+## ppc64le-specific notes
+
+- **`python3.13` is not in UBI 10's dnf repos.** The script uses `uv python install 3.13` instead, which downloads a pre-built standalone CPython 3.13 ppc64le binary — no compilation required.
+
+- **ppc64le devpi index.** Several packages on PyPI have no ppc64le wheel and fail to build from source (tiktoken, grpcio, and ~30 others). The script sets `UV_EXTRA_INDEX_URL` to `https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/` which provides pre-built ppc64le wheels for all of them.
+
+- **Patched source branch.** The `ppc64le-0.5.1` branch on `afsanjar/openrag` carries a set of patches over the upstream `langflow-ai/openrag` `refactor-image-config` branch. The full diff is available as `ppc64le-consolidated.patch` in that branch. Key changes:
+  - `pyproject.toml`: pins `tiktoken<0.13.0` and `grpcio==1.80.0`; adds `[tool.uv.sources]` to pull those from the ppc64le index
+  - `docker-compose.yml`: replaces fixed image tags with overridable env vars (`OPENSEARCH_IMAGE`, `LANGFLOW_IMAGE`, `DASHBOARDS_IMAGE`) for ppc64le-compatible images; reduces `stop_grace_period` from 2m to 30s
+  - `src/tui/main.py`: replaces Alpine container chown with native `os.chown` (avoids `docker.io` pull on air-gapped hosts)
+  - `src/tui/managers/docling_manager.py`: pins `docling-serve==1.20.0`, adds `ray`, `kfp`, `av`, `pyarrow`, `scipy` pins, constrains `opencv-python-headless<5` and `pillow<12` on ppc64le
+
+## Installing the wheel directly (alternative to the tarball)
+
+After extracting the wheel above, you can install and run OpenRAG without the
+full embedded install script. This is useful for iterative testing:
+
+```bash
+# Copy wheel to the target Power machine
+scp ~/openrag-dist/openrag-0.5.1-py3-none-any.whl root@<power-machine>:~/
+
+# On the Power machine
+uv venv --python 3.13 ~/openrag-venv
+source ~/openrag-venv/bin/activate
+uv pip install ~/openrag-0.5.1-py3-none-any.whl \
+  --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/ \
+  --index-strategy unsafe-best-match
+openrag
+```
+
+Note: the direct wheel install skips container image pulls and `.env` setup.
+You still need to configure `~/.openrag/tui/.env` and start the stack manually
+via the TUI. See the tarball `README.md` for the full end-to-end flow.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Build, install, and import verification all passed |
+| `1` | Clone, build, or install step failed |
+| `2` | Import verification failed (package installed but not importable) |
+
+## Maintainer
+
+Kamryn Schock — kamrynschock@ibm.com

--- a/o/openrag/README.md
+++ b/o/openrag/README.md
@@ -104,7 +104,7 @@ openrag
 
 Note: the direct wheel install skips container image pulls and `.env` setup.
 You still need to configure `~/.openrag/tui/.env` and start the stack manually
-via the TUI. See the tarball `README.md` for the full end-to-end flow.
+via the TUI.
 
 ## Exit codes
 

--- a/o/openrag/build_info.json
+++ b/o/openrag/build_info.json
@@ -1,0 +1,9 @@
+{
+    "package_name": "openrag",
+    "package_version": "0.5.1",
+    "source_url": "https://github.com/afsanjar/openrag",
+    "branch": "ppc64le-0.5.1",
+    "tested_on": "UBI:10.0",
+    "language": "Python",
+    "maintainer": "Kamryn Schock <kamrynschock@ibm.com>"
+}

--- a/o/openrag/build_info.json
+++ b/o/openrag/build_info.json
@@ -1,9 +1,12 @@
 {
     "package_name": "openrag",
-    "package_version": "0.5.1",
-    "source_url": "https://github.com/afsanjar/openrag",
-    "branch": "ppc64le-0.5.1",
+    "github_url": "https://github.com/afsanjar/openrag",
+    "version": "0.5.1",
+    "default_branch": "ppc64le-0.5.1",
+    "build_script": "openrag_v0.5.1_ubi_10.0.sh",
+    "package_dir": "o/openrag",
+    "maintainer": "Kamryn Schock <kamrynschock@ibm.com>",
+    "use_non_root_user": false,
     "tested_on": "UBI:10.0",
-    "language": "Python",
-    "maintainer": "Kamryn Schock <kamrynschock@ibm.com>"
+    "language": "Python"
 }

--- a/o/openrag/openrag_v0.5.1_ubi_10.0.sh
+++ b/o/openrag/openrag_v0.5.1_ubi_10.0.sh
@@ -1,0 +1,99 @@
+#!/bin/bash -e
+# -----------------------------------------------------------------------------
+#
+# Package       : openrag
+# Version       : 0.5.1
+# Source repo   : https://github.com/afsanjar/openrag
+# Tested on     : UBI:10.0
+# Language      : Python
+# Ci-Check      : True
+# Script License: Apache License, Version 2 or later
+# Maintainer    : Kamryn Schock kamrynschock@ibm.com
+#
+# Disclaimer: This script has been tested in root mode on given
+# ==========  platform using the mentioned version of the package.
+#             It may not work as expected with newer versions of the
+#             package and/or distribution. In such case, please
+#             contact "Maintainer" of this script.
+#
+# -----------------------------------------------------------------------------
+
+set -ex
+
+PACKAGE_NAME=openrag
+PACKAGE_VERSION=${1:-0.5.1}
+PACKAGE_URL=https://github.com/afsanjar/openrag
+PACKAGE_BRANCH=ppc64le-0.5.1
+PACKAGE_DIR=openrag
+OS_NAME=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2)
+
+# -----------------------------------------------------------------------------
+# System dependencies
+# -----------------------------------------------------------------------------
+dnf install -y \
+    git curl wget \
+    gcc gcc-c++ make \
+    openblas-devel \
+    && dnf clean all
+
+# Install uv (required by openrag's build system)
+# uv manages its own Python 3.13 download — no system python3.13 package needed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# Fetch Python 3.13 via uv (downloads a standalone ppc64le build)
+uv python install 3.13
+
+# -----------------------------------------------------------------------------
+# Clone
+# -----------------------------------------------------------------------------
+if ! git clone --branch "$PACKAGE_BRANCH" --depth 1 "$PACKAGE_URL" "$PACKAGE_DIR"; then
+    echo "------------------$PACKAGE_NAME:clone_fails---------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail | Clone_Fails"
+    exit 1
+fi
+
+cd "$PACKAGE_DIR"
+
+# -----------------------------------------------------------------------------
+# Configure ppc64le-compatible index and build the wheel
+# -----------------------------------------------------------------------------
+export UV_EXTRA_INDEX_URL="https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/"
+export UV_INDEX_STRATEGY="unsafe-best-match"
+
+# Remove lock file so uv resolves fresh against the ppc64le index
+rm -f uv.lock
+
+if ! uv build --python 3.13; then
+    echo "------------------$PACKAGE_NAME:build_fails---------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail | Build_Fails"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Install the built wheel into a venv and verify
+# -----------------------------------------------------------------------------
+WHEEL=$(ls dist/${PACKAGE_NAME}-*.whl | head -1)
+
+uv venv --python 3.13 /tmp/openrag-venv
+
+if ! uv pip install --python /tmp/openrag-venv \
+        --extra-index-url "https://wheels.developerfirst.ibm.com/ppc64le/linux/+simple/" \
+        --index-strategy unsafe-best-match \
+        "$WHEEL"; then
+    echo "------------------$PACKAGE_NAME:install_fails-------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail | Install_Fails"
+    exit 1
+fi
+
+# The wheel installs modules at the top level (tui/, utils/, api/, etc.) rather
+# than under an 'openrag' namespace — verify the installed entry point module loads.
+if ! /tmp/openrag-venv/bin/python -c "import tui.main"; then
+    echo "------------------$PACKAGE_NAME:import_fails--------------------"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Fail | Import_Fails"
+    exit 2
+fi
+
+echo "------------------$PACKAGE_NAME:build_and_install_success----------"
+echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | $OS_NAME | GitHub | Pass | Build_and_Install_Success"
+exit 0


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


**Notes:**
- Tested on UBI 10.0 only (not UBI 9) — `Tested on: UBI:10.0` reflects this
- No patch files in this PR; ppc64le changes are in the source branch (`afsanjar/openrag@ppc64le-0.5.1`)
- `python3.13` is not available in UBI 10 dnf repos; script uses `uv python install 3.13` instead
- Build log from fresh UBI 10 container on ppc64le (Power10):

```
+ echo ------------------openrag:build_and_install_success----------
------------------openrag:build_and_install_success----------
+ echo 'openrag | https://github.com/afsanjar/openrag | 0.5.1 | "Red Hat Enterprise Linux 10.0 (Coughlan)" | GitHub | Pass | Build_and_Install_Success'
openrag | https://github.com/afsanjar/openrag | 0.5.1 | "Red Hat Enterprise Linux 10.0 (Coughlan)" | GitHub | Pass | Build_and_Install_Success
+ exit 0
```
