### PR TITLE
Scanner evn permission issue

### DIFF
--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -76,7 +76,7 @@ jobs:
       script_ubi10: ${{ steps.emit.outputs.script_ubi10 }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system packages
         run: |
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -212,7 +212,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi8).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi8).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -223,6 +223,7 @@ jobs:
         env:
           GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
         run: |
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
           export BUILD_SCRIPT="${{ fromJson(needs.build_info.outputs.script_ubi8).script }}"
@@ -234,8 +235,9 @@ jobs:
           bash ./gha-script/build_package.sh
           cloned_package=$(ls -td -- */ | head -n 1)
           sudo mv "$cloned_package" package-cache/
-          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> package-cache/scanner-env.sh
-          cd package-cache && sudo chown $USER:$USER -R .
+          sudo chown -R $USER:$USER .
+          cd package-cache
+          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> scanner-env.sh
           chmod +x ../gha-script/pre_process.sh
           bash ../gha-script/pre_process.sh
           cd $GITHUB_WORKSPACE
@@ -260,7 +262,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -271,6 +273,7 @@ jobs:
         env:
           GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
         run: |
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
           export BUILD_SCRIPT="${{ fromJson(needs.build_info.outputs.script_ubi9).script }}"
@@ -282,8 +285,9 @@ jobs:
           bash ./gha-script/build_package.sh
           cloned_package=$(ls -td -- */ | head -n 1)
           sudo mv "$cloned_package" package-cache/
-          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> package-cache/scanner-env.sh
-          cd package-cache && sudo chown $USER:$USER -R .
+          sudo chown -R $USER:$USER .
+          cd package-cache
+          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> scanner-env.sh
           chmod +x ../gha-script/pre_process.sh
           bash ../gha-script/pre_process.sh
           cd $GITHUB_WORKSPACE
@@ -308,7 +312,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi10).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi10).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -319,6 +323,7 @@ jobs:
         env:
           GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
         run: |
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
           export BUILD_SCRIPT="${{ fromJson(needs.build_info.outputs.script_ubi10).script }}"
@@ -330,8 +335,9 @@ jobs:
           bash ./gha-script/build_package.sh
           cloned_package=$(ls -td -- */ | head -n 1)
           sudo mv "$cloned_package" package-cache/
-          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> package-cache/scanner-env.sh
-          cd package-cache && sudo chown $USER:$USER -R .
+          sudo chown -R $USER:$USER .
+          cd package-cache
+          echo "export CLONED_PACKAGE=\"$cloned_package\"" >> scanner-env.sh
           chmod +x ../gha-script/pre_process.sh
           bash ../gha-script/pre_process.sh
           cd $GITHUB_WORKSPACE
@@ -368,7 +374,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -458,7 +464,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -548,7 +554,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -632,7 +638,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -716,7 +722,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -801,7 +807,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -886,7 +892,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -972,7 +978,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -1057,7 +1063,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -1142,7 +1148,7 @@ jobs:
       GHA_CURRENCY_SERVICE_ID_API_KEY: ${{ secrets.GHA_CURRENCY_SERVICE_ID_API_KEY }}
       GHA_CURRENCY_SERVICE_ID:         ${{ secrets.GHA_CURRENCY_SERVICE_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install system dependencies
@@ -1231,7 +1237,7 @@ jobs:
        needs.wheel_build_ubi8_py312.result == 'success')
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -1281,7 +1287,7 @@ jobs:
        needs.wheel_build_ubi9_py314.result == 'success')
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -1327,7 +1333,7 @@ jobs:
        needs.wheel_build_ubi10_py314.result == 'success')
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -1369,7 +1375,7 @@ jobs:
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi8.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download updated package-cache (UBI8)
         uses: actions/download-artifact@v4
         with:
@@ -1434,7 +1440,7 @@ jobs:
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi9.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download updated package-cache (UBI9)
         uses: actions/download-artifact@v4
         with:
@@ -1499,7 +1505,7 @@ jobs:
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi10.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download updated package-cache (UBI10)
         uses: actions/download-artifact@v4
         with:
@@ -1567,7 +1573,7 @@ jobs:
     if: ${{ inputs.build_docker == 'true' }}
     runs-on: ${{ inputs.large-runner-label != '' && inputs.large-runner-label || 'ubuntu-24.04-ppc64le-p10' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -1603,7 +1609,7 @@ jobs:
     if: ${{ inputs.build_docker == 'true' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:
@@ -1684,7 +1690,7 @@ jobs:
        needs.build_ubi10.result == 'success')
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download package-cache
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -91,14 +91,14 @@ jobs:
     steps:
       - name: Checkout code (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout code (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ inputs.pr_number }}/head
 
@@ -464,7 +464,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi8).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi8).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download package-cache
@@ -478,9 +478,9 @@ jobs:
           # Capture the GHA job-level BUILD_SCRIPT before sourcing variable.sh,
           # which overwrites BUILD_SCRIPT with the first/backward-compat script.
           THIS_SCRIPT="$BUILD_SCRIPT"
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
-          sudo chown -R $USER:$USER .
           echo "--- Executing changed scripts for UBI8 (script: $THIS_SCRIPT) ---"
           # Filter CHANGED_FILES to only the script assigned to this UBI job.
           export CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -F "$THIS_SCRIPT" || true)
@@ -496,7 +496,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download package-cache
@@ -508,9 +508,9 @@ jobs:
       - name: Build Package (UBI9)
         run: |
           THIS_SCRIPT="$BUILD_SCRIPT"
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
-          sudo chown -R $USER:$USER .
           echo "--- Executing changed scripts for UBI9 (script: $THIS_SCRIPT) ---"
           export CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -F "$THIS_SCRIPT" || true)
           export BUILD_SCRIPT="$THIS_SCRIPT"
@@ -525,7 +525,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi10).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi10).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download package-cache
@@ -537,9 +537,9 @@ jobs:
       - name: Build Package (UBI10)
         run: |
           THIS_SCRIPT="$BUILD_SCRIPT"
+          sudo chown -R $USER:$USER .
           source package-cache/variable.sh
           source package-cache/scanner-env.sh
-          sudo chown -R $USER:$USER .
           echo "--- Executing changed scripts for UBI10 (script: $THIS_SCRIPT) ---"
           export CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -F "$THIS_SCRIPT" || true)
           export BUILD_SCRIPT="$THIS_SCRIPT"
@@ -561,7 +561,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi8).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi8).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -604,7 +604,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi8).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi8).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -649,7 +649,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -692,7 +692,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -735,7 +735,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -779,7 +779,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -823,7 +823,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi9).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi9).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -868,7 +868,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi10).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi10).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -912,7 +912,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi10).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi10).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -956,7 +956,7 @@ jobs:
       BUILD_SCRIPT: ${{ fromJson(needs.build_info.outputs.script_ubi10).script }}
       TESTED_ON:    ${{ fromJson(needs.build_info.outputs.script_ubi10).tested_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -999,7 +999,7 @@ jobs:
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04-ppc64le-p10' || inputs.large-runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Download package-cache


### PR DESCRIPTION
## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 


* fix: restore full workspace ownership after Docker build in UBI build jobs

After build_package.sh runs a Docker container as test_user, the entire
workspace is left owned by root. Replaced `cd package-cache && sudo chown
$USER:$USER -R .` with `sudo chown -R $USER:$USER .` (from workspace root)
followed by `cd package-cache`, so that gha-script/ and other directories
are re-owned before chmod is called on them. Applied to build_ubi8,
build_ubi9, and build_ubi10 jobs.

* fix: add workspace chown before sourcing package-cache files in build jobs

Docker container runs leave workspace files owned by root, causing
Permission denied when sourcing package-cache/scanner-env.sh and writing
to package-cache/scanner-env.sh. Added `sudo chown -R $USER:$USER .` at
the start of each UBI build step (build_ubi8, build_ubi9, build_ubi10)
and updated actions/checkout from v4 to v6.