### PR TITLE
added fix for correct wheel installation

### DIFF
--- a/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
+++ b/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
@@ -55,10 +55,10 @@ uv build --wheel --config-setting wheel.py-api=cp$CP --extra-index-url $INDEX_UR
 
 WHEEL_PATH=$(find dist -maxdepth 1 -type f -name 'faiss_cpu-*.whl' | head -1)
 
-if [ -z "$WHEEL_PATH" ]; then
-    echo "------------------$PACKAGE_NAME:Wheel not found------------------"
+if [ -z "$WHEEL" ]; then
+    echo "------------------$PACKAGE_NAME:Failed to build wheel (no wheel found in dist/)-------------------------------------"
     echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Wheel_Not_Found"
+    echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
     exit 1
 fi
 

--- a/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
+++ b/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
@@ -53,10 +53,22 @@ sed -i '/^\[project\]/,/^$/ {s/version = "[^"]*"/version = "'"$PACKAGE_VERSION"'
 
 uv build --wheel --config-setting wheel.py-api=cp$CP --extra-index-url $INDEX_URL_DEVPY
 
-if ! (python3 -m pip install dist/faiss_cpu-$PACKAGE_VERSION-cp$CP-abi3-linux_ppc64le.whl ); then
-   echo "------------------$PACKAGE_NAME:Failed to build wheel-------------------------------------"
-   echo "$PACKAGE_URL $PACKAGE_NAME"
-   echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
+WHEEL_PATH=$(find dist -maxdepth 1 -type f -name 'faiss_cpu-*.whl' | head -1)
+
+if [ -z "$WHEEL_PATH" ]; then
+    echo "------------------$PACKAGE_NAME:Wheel not found------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Wheel_Not_Found"
+    exit 1
+fi
+
+echo "Installing wheel: $WHEEL_PATH"
+
+if ! python3 -m pip install "$WHEEL_PATH"; then
+    echo "------------------$PACKAGE_NAME:Failed to install wheel------------------"
+    echo "$PACKAGE_URL $PACKAGE_NAME"
+    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Install_Fails"
+    exit 1
 fi
 
 # Run tests

--- a/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
+++ b/f/faiss-cpu/faiss-cpu_1.9.0.post1_ubi_10.2.sh
@@ -53,7 +53,7 @@ sed -i '/^\[project\]/,/^$/ {s/version = "[^"]*"/version = "'"$PACKAGE_VERSION"'
 
 uv build --wheel --config-setting wheel.py-api=cp$CP --extra-index-url $INDEX_URL_DEVPY
 
-WHEEL_PATH=$(find dist -maxdepth 1 -type f -name 'faiss_cpu-*.whl' | head -1)
+WHEEL=$(find dist -maxdepth 1 -type f -name 'faiss_cpu-*.whl' | head -1)
 
 if [ -z "$WHEEL" ]; then
     echo "------------------$PACKAGE_NAME:Failed to build wheel (no wheel found in dist/)-------------------------------------"
@@ -62,13 +62,15 @@ if [ -z "$WHEEL" ]; then
     exit 1
 fi
 
-echo "Installing wheel: $WHEEL_PATH"
+# Copy wheel to CURRENT_DIR so create_wheel_wrapper.sh can find it
+cp "$WHEEL" "${CURRENT_DIR:-$(pwd)}/"
 
-if ! python3 -m pip install "$WHEEL_PATH"; then
-    echo "------------------$PACKAGE_NAME:Failed to install wheel------------------"
-    echo "$PACKAGE_URL $PACKAGE_NAME"
-    echo "$PACKAGE_NAME | $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail | Install_Fails"
-    exit 1
+echo "Installing wheel: $WHEEL"
+
+if ! (python3 -m pip install "$WHEEL" ); then
+   echo "------------------$PACKAGE_NAME:Failed to build wheel-------------------------------------"
+   echo "$PACKAGE_URL $PACKAGE_NAME"
+   echo "$PACKAGE_NAME  |  $PACKAGE_URL | $PACKAGE_VERSION | GitHub | Fail |  Install_Fails"
 fi
 
 # Run tests


### PR DESCRIPTION
Issue:
```
*** Making wheel...
*** Created faiss_cpu-1.9.0.post1-cp312-abi3-linux_ppc64le.whl
Successfully built dist/faiss_cpu-1.9.0.post1-cp312-abi3-linux_ppc64le.whl
WARNING: Requirement 'dist/faiss_cpu-v1.9.0.post1-cp312-abi3-linux_ppc64le.whl' looks like a filename, but the file does not exist
Processing ./dist/faiss_cpu-v1.9.0.post1-cp312-abi3-linux_ppc64le.whl
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/home/tester/faiss-wheels/dist/faiss_cpu-v1.9.0.post1-cp312-abi3-linux_ppc64le.whl'

```
wheel created is this: `faiss_cpu-1.9.0.post1-cp312-abi3-linux_ppc64le.whl`
script searches for this: `faiss_cpu-v1.9.0.post1-cp312-abi3-linux_ppc64le.whl`

add fix to resolve this issue

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
