### PR TITLE
fix(opensearch-jvector): remove chown of /home/tester

### DIFF
--- a/o/opensearch-jvector/opensearch-jvector_3.6.0.0_ubi_9.6.sh
+++ b/o/opensearch-jvector/opensearch-jvector_3.6.0.0_ubi_9.6.sh
@@ -39,7 +39,7 @@ sudo dnf install -y java-25-openjdk-devel
 export JAVA_HOME=/usr/lib/jvm/java-25-openjdk
 export PATH="/usr/local/bin:$HOME/.local/bin:$JAVA_HOME/bin:$PATH"
 
-sudo chown -R test_user:test_user /home/tester
+
 
 # -------------------------------
 # Remove existing repositories (if they exist)


### PR DESCRIPTION
Container already runs as test_user with passwordless sudo, so the chown
is unnecessary. Via the bind-mount it also corrupts host workspace
ownership, breaking subsequent CI steps.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
