### PR TITLE
Fix opensearch jvector and opensearch-prometheus-exporter build-info.json

### DIFF
--- a/o/opensearch-jvector/build_info.json
+++ b/o/opensearch-jvector/build_info.json
@@ -10,7 +10,7 @@
   "validate_build_script": true,
   "use_non_root_user": true,
   "docker_build": false,
-  "wheel_build": true,
+  "wheel_build": false,
   "3.0.0.4": {
     "build_script": "opensearch-jvector_3.0.0.4_ubi_9.6.sh" 
   },

--- a/o/opensearch-prometheus-exporter/build_info.json
+++ b/o/opensearch-prometheus-exporter/build_info.json
@@ -10,7 +10,7 @@
   "validate_build_script": true,
   "use_non_root_user": true,
   "docker_build": false,
-  "wheel_build": true,
+  "wheel_build": false,
   "3.2.0.0": {
     "build_script": "opensearch-prometheus-exporter_3.2.0.0_ubi_9.6.sh" 
   },


### PR DESCRIPTION
- As mentioned in this [comment](https://github.ibm.com/ppc64le-automation/python-ecosystem/issues/2271#issuecomment-235888073) wheels for these packages are not needed, so set wheel_build to false.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
