### PR TITLE
fix(scipy): support v1.18.1 and future versions via wildcard fallback

### DIFF
--- a/s/scipy/build_info.json
+++ b/s/scipy/build_info.json
@@ -21,5 +21,8 @@
   },
   "v1.18.0": {
     "build_script": "scipy_v1.18.0_ubi_9.6.sh"
+  },
+  "*": {
+    "build_script": "scipy_v1.18.0_ubi_9.6.sh"
   }
 }

--- a/s/scipy/scipy_v1.18.0_ubi_9.6.sh
+++ b/s/scipy/scipy_v1.18.0_ubi_9.6.sh
@@ -61,11 +61,12 @@ python3.12 -m pip install "$WHEEL"
 # -- Tests --------------------------------------------------------------------
 cd "${SOURCE_ROOT}"   # <-- leave the source tree before importing scipy
 
-python3.12 - << 'PYEOF'
+python3.12 - << PYEOF
 import sys
 
 import scipy
-assert scipy.__version__ == "1.18.0", f"Unexpected version: {scipy.__version__}"
+expected = "${PACKAGE_VERSION#v}"
+assert scipy.__version__ == expected, f"Unexpected version: {scipy.__version__} (expected {expected})"
 print(f"PASS  import scipy {scipy.__version__}")
 
 import scipy.linalg, scipy.fft, scipy.optimize, scipy.stats, scipy.signal, scipy.sparse


### PR DESCRIPTION
### Changes
- Add `"*"` wildcard entry in `build_info.json` pointing to `scipy_v1.18.0_ubi_9.6.sh` so any version without an explicit key resolves to the latest build script
- Fix version assertion in `scipy_v1.18.0_ubi_9.6.sh`: remove quotes from the heredoc opening delimiter (`<< 'PYEOF'` → `<< PYEOF`) so the shell expands `${PACKAGE_VERSION#v}` dynamically before passing it to Python

### Root Cause
Currency build for `v1.18.1` was failing because:
1. No `"*"` wildcard fallback in `build_info.json` (silently fell back to top-level `build_script`, which happened to be correct but is implicit)
2. The heredoc used `<< 'PYEOF'` (single-quoted), which suppresses all shell expansion inside the block — `${PACKAGE_VERSION#v}` was passed as a literal string to Python instead of the actual version value, causing the assertion to always fail for any version other than `1.18.0`

---

## Checklist
- [x] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [x] Have you validated script on UBI 9 container
- [x] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ?
