### PR TITLE
Modify source_scanner jobs to depend on install_scan_tools

### DIFF
--- a/.github/workflows/currency-build.yaml
+++ b/.github/workflows/currency-build.yaml
@@ -142,11 +142,12 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # install_scan_tools: installs grype + fetches scancode-toolkit source ONCE.
-  # Skipped entirely when wheel_build=false.
+  # Runs when wheel_build=true (scancode needed for wheels) OR enable_grype=true
+  # (grype needed for source/image scanners).
   # ---------------------------------------------------------------------------
   install_scan_tools:
     needs: build_info
-    if: ${{ inputs.wheel_build == 'true' }}
+    if: ${{ inputs.wheel_build == 'true' || inputs.enable_grype == 'true' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
       - name: Checkout code
@@ -1371,7 +1372,7 @@ jobs:
   # Only runs when the corresponding build_ubiN succeeded and has a script.
   # ---------------------------------------------------------------------------
   source_scanner_ubi8:
-    needs: build_ubi8
+    needs: [build_ubi8, install_scan_tools]
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi8.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
@@ -1436,7 +1437,7 @@ jobs:
           bash ./gha-script/upload-scripts/upload_file.sh source_scanner_ubi8.tar.gz
 
   source_scanner_ubi9:
-    needs: build_ubi9
+    needs: [build_ubi9, install_scan_tools]
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi9.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:
@@ -1501,7 +1502,7 @@ jobs:
           bash ./gha-script/upload-scripts/upload_file.sh source_scanner_ubi9.tar.gz
 
   source_scanner_ubi10:
-    needs: build_ubi10
+    needs: [build_ubi10, install_scan_tools]
     if: ${{ always() && inputs.validate_build_script == 'true' && needs.build_ubi10.result == 'success' }}
     runs-on: ubuntu-24.04-ppc64le-p10
     steps:


### PR DESCRIPTION
Updated job dependencies to include install_scan_tools for source_scanner jobs.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 





