### PR TITLE
fix: strip trailing slash from PACKAGE_DIR in scanner-env.sh to fix w…

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -418,6 +418,10 @@ jobs:
           mkdir -p package-cache
 
           PACKAGE_DIR=$(jq -r '.package_dir // ""' $BUILD_INFO_FILE)
+          # Strip trailing slash to prevent double-slash in the per-job grep:
+          #   grep -E "^$PACKAGE_DIR/.*\.sh$"
+          # Without this, "n/nbconvert/" becomes "n/nbconvert//.*\.sh$" and never matches.
+          PACKAGE_DIR="${PACKAGE_DIR%/}"
           WHEEL_BUILD=$(jq -r '.wheel_build // "false"' $BUILD_INFO_FILE)
 
           # Robust docker_build extraction


### PR DESCRIPTION
…heel build CI

## Problem
Wheel build jobs always skipped with `Skipping - no .sh changes` even when a `.sh` file was changed.

## Root Cause
`PACKAGE_DIR` was read from `build_info.json` without stripping the trailing slash (e.g. `"n/nbconvert/"`), causing the wheel job grep to expand as:

  grep -E "^n/nbconvert//.*\.sh$"   ← double slash, never matches

## Fix
Added `PACKAGE_DIR="${PACKAGE_DIR%/}"` in the "Create scanner-env.sh" step, mirroring what the "Set job control flags" step already does correctly.

## Checklist
<!--- Goto Preview tab for better readability -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Have you checked and followed all the points mention in the [CONTRIBUTING.MD](https://github.com/ppc64le/build-scripts/blob/master/CONTRIBUTING.md)
- [ ] Have you validated script on UBI 9 container
- [ ] Did you run the script(s) on fresh container with `set -e` option enabled and observe success ?
- [ ] Did you have **Legal approvals** for patch files ? 
